### PR TITLE
Don't specify build command in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
 [build]
     base    = "frontend"
     publish = "frontend/build_storybook"
-    command = "yarn build:storybook"


### PR DESCRIPTION
This should allow us to use different commands
on different sites, so we can build the frontend
and the styleguide on two different sites.