### PR TITLE
Use material components web/react

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,2 +1,3 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Rubik:500,700" rel="stylesheet">
 <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -1,1 +1,2 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Rubik:500,700" rel="stylesheet">
+<link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material/ripple": "^0.35.0",
     "react": "16.4.0",
     "react-dom": "16.4.0",
     "react-feather": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material/ripple": "^0.35.0",
+    "@material/top-app-bar": "^0.35.2",
     "react": "16.4.0",
     "react-dom": "16.4.0",
     "react-feather": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@material/ripple": "^0.35.0",
     "@material/top-app-bar": "^0.35.2",
+    "@types/classnames": "^2.2.3",
+    "classnames": "^2.2.5",
     "react": "16.4.0",
     "react-dom": "16.4.0",
     "react-feather": "1.1.0",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Rubik:500,700" rel="stylesheet">
     <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
 
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Rubik:500,700" rel="stylesheet">
+    <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import Button from './vendor/react-material/button';
+
 class App extends React.Component {
   render() {
     return (
@@ -10,6 +12,8 @@ class App extends React.Component {
         <p className="App-intro">
           To get started, edit <code>src/App.tsx</code> and save to reload.
         </p>
+
+        <Button>Hello :)</Button>
       </div>
     );
   }

--- a/frontend/src/components/button/index.tsx
+++ b/frontend/src/components/button/index.tsx
@@ -1,61 +1,41 @@
 import React, { AnchorHTMLAttributes } from 'react';
-import { Box } from '../box';
+
+import MaterialButton from '../../vendor/react-material/button';
+
 import { ButtonVariant } from './types';
-import {
-  getBackgroundColor,
-  getFontSize,
-  getBorderColor,
-  getBorder,
-  getTextColor,
-} from './utils';
 
 type Props = {
   variant?: ButtonVariant;
   children: React.ReactNode;
 };
 
-const Base = Box.extend`
-  transition: background-color ${props => props.theme.timings[0]}s ease-out,
-    color ${props => props.theme.timings[0]}s ease-out;
-  cursor: pointer;
-  text-transform: uppercase;
-  text-decoration: none;
-  font-family: ${props => props.theme.fonts.button};
-  display: inline-block;
-`;
-
 const button = (
   { variant, children, ...additionalProps }: Props,
   tagName: 'a' | 'button',
 ) => {
-  const Component = Base.withComponent(tagName);
-
   return (
-    <Component
-      px={3}
-      py={2}
-      borderRadius={100}
-      bg={getBackgroundColor(variant, false)}
-      color={getTextColor(variant, false)}
-      fontSize={getFontSize(variant)}
-      borderColor={getBorderColor(variant)}
-      border={getBorder(variant, false)}
-      hover={{
-        backgroundColor: getBackgroundColor(variant, true),
-        color: getTextColor(variant, true),
-      }}
-      focus={{
-        backgroundColor: getBackgroundColor(variant, true),
-        color: getTextColor(variant, true),
-      }}
+    <MaterialButton
+      tagName={tagName}
+      unelevated={variant === 'primary' ? true : false}
+      outlined={variant === 'primary' ? false : true}
       {...additionalProps}
     >
       {children}
-    </Component>
+    </MaterialButton>
   );
 };
 
 type ButtonLinkProps = Props & AnchorHTMLAttributes<HTMLAnchorElement>;
 
-export const Button = (props: Props) => button(props, 'button');
-export const ButtonLink = (props: ButtonLinkProps) => button(props, 'a');
+export const Button: React.SFC<Props> = (props: Props) =>
+  button(props, 'button');
+export const ButtonLink: React.SFC<ButtonLinkProps> = (
+  props: ButtonLinkProps,
+) => button(props, 'a');
+
+Button.defaultProps = {
+  variant: 'primary',
+};
+ButtonLink.defaultProps = {
+  variant: 'primary',
+};

--- a/frontend/src/components/button/stories.tsx
+++ b/frontend/src/components/button/stories.tsx
@@ -6,4 +6,4 @@ import { Button, ButtonLink } from '.';
 storiesOf('Button', module)
   .add('default', () => <Button>Hello world</Button>)
   .add('secondary', () => <Button variant="secondary">Hello world</Button>)
-  .add('link default', () => <ButtonLink>Hello world</ButtonLink>);
+  .add('link default', () => <ButtonLink href="/">Hello world</ButtonLink>);

--- a/frontend/src/components/grid/index.tsx
+++ b/frontend/src/components/grid/index.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
-import { Box } from '../box';
+
+import cx from 'classnames';
 
 type ColumnProps = {
-  width: number;
+  cols?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 };
 
 export const Column: React.SFC<ColumnProps> = ({
-  width,
+  cols,
   children,
   ...props
-}) => (
-  <Box px={2} py={1} width={width} {...props}>
-    {children}
-  </Box>
-);
+}) => {
+  const classes = cx('mdc-layout-grid__cell', {
+    [`mdc-layout-grid__cell--span-${cols}`]: !!cols,
+  });
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+};
 
 export const Grid: React.SFC = ({ children, ...props }) => (
-  <Box flexWrap="wrap" display="flex" {...props}>
-    {children}
-  </Box>
+  <div className="mdc-layout-grid" {...props}>
+    <div className="mdc-layout-grid__inner">{children}</div>
+  </div>
 );

--- a/frontend/src/components/grid/stories.tsx
+++ b/frontend/src/components/grid/stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import styled from '../../styled';
-import { Title } from '../typography';
 import { Grid, Column } from '.';
 
 const Bar = styled.hr`
@@ -12,104 +11,70 @@ const Bar = styled.hr`
   background-image: linear-gradient(90deg, rgb(0, 255, 255), rgb(255, 0, 255));
 `;
 
-storiesOf('Grid', module)
-  .add('simple', () => (
-    <Grid>
-      <Column width={1 / 2}>
-        <Bar />
-        1/2
-      </Column>
-      <Column width={1 / 2}>
-        <Bar />
-        1/2
-      </Column>
+storiesOf('Grid', module).add('simple', () => (
+  <Grid>
+    <Column cols={6}>
+      <Bar />
+      1/2
+    </Column>
+    <Column cols={6}>
+      <Bar />
+      1/2
+    </Column>
 
-      <Column width={1 / 3}>
-        <Bar />
-        1/3
-      </Column>
-      <Column width={1 / 3}>
-        <Bar />
-        1/3
-      </Column>
-      <Column width={1 / 3}>
-        <Bar />
-        1/3
-      </Column>
+    <Column cols={4}>
+      <Bar />
+      1/3
+    </Column>
+    <Column cols={4}>
+      <Bar />
+      1/3
+    </Column>
+    <Column cols={4}>
+      <Bar />
+      1/3
+    </Column>
 
-      <Column width={1 / 4}>
-        <Bar />
-        1/4
-      </Column>
-      <Column width={1 / 4}>
-        <Bar />
-        1/4
-      </Column>
-      <Column width={1 / 4}>
-        <Bar />
-        1/4
-      </Column>
-      <Column width={1 / 4}>
-        <Bar />
-        1/4
-      </Column>
+    <Column cols={3}>
+      <Bar />
+      1/4
+    </Column>
+    <Column cols={3}>
+      <Bar />
+      1/4
+    </Column>
+    <Column cols={3}>
+      <Bar />
+      1/4
+    </Column>
+    <Column cols={3}>
+      <Bar />
+      1/4
+    </Column>
 
-      <Column width={1 / 5}>
-        <Bar />
-        1/5
-      </Column>
-      <Column width={1 / 5}>
-        <Bar />
-        1/5
-      </Column>
-      <Column width={1 / 5}>
-        <Bar />
-        1/5
-      </Column>
-      <Column width={1 / 5}>
-        <Bar />
-        1/5
-      </Column>
-      <Column width={1 / 5}>
-        <Bar />
-        1/5
-      </Column>
-
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-      <Column width={1 / 6}>
-        <Bar />
-        1/6
-      </Column>
-    </Grid>
-  ))
-  .add('golden ratio', () => (
-    <Grid>
-      <Column width={(1 + Math.sqrt(5)) / 2 - 1}>
-        <Title level={1}>Golden</Title>
-        <Bar />
-      </Column>
-      <Column width={1 - ((1 + Math.sqrt(5)) / 2 - 1)}>
-        <Title level={1}>Ratio</Title>
-        <Bar />
-      </Column>
-    </Grid>
-  ));
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+    <Column cols={2}>
+      <Bar />
+      1/6
+    </Column>
+  </Grid>
+));

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -1,30 +1,18 @@
 import React from 'react';
 
-import { Menu } from 'react-feather';
-import { Box } from '../box';
-import { Logo } from '../logo';
-import { ButtonLink } from '../button';
-import { Link } from '../link';
+import TopAppBar from '../../vendor/react-material/top-app-bar';
+import MaterialIcon from '../../vendor/react-material/material-icon';
 
 export class Navbar extends React.Component<{}, {}> {
   render() {
     return (
-      <Box p={3} flexDirection="row" display="flex" alignItems="center">
-        <Box p={2} display={['block', 'none']}>
-          <Menu />
-        </Box>
-
-        <Logo />
-
-        <Box ml="auto" flexDirection="row" display="flex" alignItems="center">
-          <Box mr={3} display={['none', 'block']}>
-            <Link href="/">Schedule</Link>
-            <Link href="/">Speaker</Link>
-            <Link href="/">FAQ</Link>
-          </Box>
-          <ButtonLink href="/">Tickets</ButtonLink>
-        </Box>
-      </Box>
+      <TopAppBar
+        title="PyCon 10"
+        navigationIcon={<MaterialIcon icon="menu" />}
+        actionItems={[<MaterialIcon key="item" icon="bookmark" />]}
+      >
+        a
+      </TopAppBar>
     );
   }
 }

--- a/frontend/src/components/typography/index.tsx
+++ b/frontend/src/components/typography/index.tsx
@@ -1,60 +1,33 @@
 import React from 'react';
-import withProps from 'recompose/withProps';
-
-import {
-  space,
-  fontSize,
-  color,
-  lineHeight,
-  fontFamily,
-  FontFamilyProps,
-  LineHeightProps,
-  SpaceProps,
-  FontSizeProps,
-  ColorProps,
-  BoxShadowProps,
-} from 'styled-system';
-
-import styled from '../../styled';
-
-type TypographyProps = SpaceProps &
-  FontSizeProps &
-  LineHeightProps &
-  ColorProps &
-  FontFamilyProps &
-  BoxShadowProps;
-
-const BaseTypography = styled<TypographyProps, 'h1'>('h1')`
-  ${space}
-  ${fontFamily}
-  ${fontSize}
-  ${lineHeight}
-  ${color}
-`;
 
 interface TitleProps {
-  level: 1 | 2 | 3;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
   children: React.ReactNode;
 }
 
-// TODO spacing etc
 export const Title = ({ level, children }: TitleProps) => {
-  // ugly, but works :)
-  const tagName: keyof JSX.IntrinsicElements = `h${level}` as keyof JSX.IntrinsicElements;
-  const name = `title${level}`;
-
-  const X = BaseTypography.withComponent(tagName);
+  const Component = `h${level}`;
 
   return (
-    <X fontSize={name} lineHeight={name} fontFamily="title">
+    <Component className={`mdc-typography mdc-typography--headline${level}`}>
       {children}
-    </X>
+    </Component>
   );
 };
 
-export const Paragraph = withProps({
-  fontFamily: 'base',
-  fontSize: 'body',
-  lineHeight: 'body',
-  mb: 3,
-})(BaseTypography.withComponent('p'));
+type ParagraphProps = {
+  variant?: 'primary' | 'secondary';
+  children: React.ReactNode;
+};
+
+export const Paragraph: React.SFC<ParagraphProps> = ({ variant, children }) => {
+  const level = variant === 'primary' ? 1 : 2;
+
+  return (
+    <p className={`mdc-typography mdc-typography--body${level}`}>{children}</p>
+  );
+};
+
+Paragraph.defaultProps = {
+  variant: 'primary',
+};

--- a/frontend/src/components/typography/stories.tsx
+++ b/frontend/src/components/typography/stories.tsx
@@ -9,10 +9,15 @@ storiesOf('Typography', module)
       <Title level={1}>Title 1</Title>
       <Title level={2}>Title 2</Title>
       <Title level={3}>Title 3</Title>
+      <Title level={4}>Title 4</Title>
+      <Title level={5}>Title 5</Title>
+      <Title level={6}>Title 6</Title>
     </div>
   ))
   .add('paragraphs', () => (
     <div>
+      <Title level={3}>Primary (default) copy</Title>
+
       <Paragraph>
         Legio eligo sed medius, negotium oblivio sed neque neque culpa lacrima
         dulcis lorem, sit quis, sit infantia gratia virtus quis in trivia trivia
@@ -20,6 +25,15 @@ storiesOf('Typography', module)
         quis impera fabula lacuna lorem medius ora.
       </Paragraph>
       <Paragraph>
+        Legio eligo sed medius, negotium oblivio sed neque neque culpa lacrima
+        dulcis lorem, sit quis, sit infantia gratia virtus quis in trivia trivia
+        benevolentia legis ergo dolor lacuna virtus insula sit canvallis caelum
+        quis impera fabula lacuna lorem medius ora.
+      </Paragraph>
+
+      <Title level={3}>Secondary copy</Title>
+
+      <Paragraph variant="secondary">
         Legio eligo sed medius, negotium oblivio sed neque neque culpa lacrima
         dulcis lorem, sit quis, sit infantia gratia virtus quis in trivia trivia
         benevolentia legis ergo dolor lacuna virtus insula sit canvallis caelum

--- a/frontend/src/vendor/react-material/button/index.js
+++ b/frontend/src/vendor/react-material/button/index.js
@@ -9,10 +9,12 @@ export class Button extends Component {
       className,
       raised,
       unelevated,
+      outlined,
       stroked,
       icon,
       children,
       initRipple,
+      tagName,
       unbounded, // eslint-disable-line no-unused-vars
       ...otherProps
     } = this.props;
@@ -20,18 +22,21 @@ export class Button extends Component {
     const classes = classnames('mdc-button', className, {
       'mdc-button--raised': raised,
       'mdc-button--unelevated': unelevated,
+      'mdc-button--outlined': outlined,
       'mdc-button--stroked': stroked,
     });
 
+    const Component = tagName || 'button';
+
     return (
-      <button
+      <Component
         className={classes}
         ref={initRipple}
         {...otherProps}
       >
         {icon ? this.renderIcon() : null}
         {children}
-      </button>
+      </Component>
     );
   }
 
@@ -50,7 +55,9 @@ export class Button extends Component {
 
 Button.propTypes = {
   raised: PropTypes.bool,
+  tagName: PropTypes.string,
   unelevated: PropTypes.bool,
+  outlined: PropTypes.bool,
   stroked: PropTypes.bool,
   disabled: PropTypes.bool,
   unbounded: PropTypes.bool,
@@ -63,6 +70,8 @@ Button.propTypes = {
 Button.defaultProps = {
   raised: false,
   unelevated: false,
+  outlined: false,
+  tagName: 'button',
   stroked: false,
   disabled: false,
   unbounded: false,

--- a/frontend/src/vendor/react-material/button/index.js
+++ b/frontend/src/vendor/react-material/button/index.js
@@ -1,0 +1,75 @@
+import React, {Component} from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import withRipple from '../ripple';
+
+export class Button extends Component {
+  render() {
+    const {
+      className,
+      raised,
+      unelevated,
+      stroked,
+      icon,
+      children,
+      initRipple,
+      unbounded, // eslint-disable-line no-unused-vars
+      ...otherProps
+    } = this.props;
+
+    const classes = classnames('mdc-button', className, {
+      'mdc-button--raised': raised,
+      'mdc-button--unelevated': unelevated,
+      'mdc-button--stroked': stroked,
+    });
+
+    return (
+      <button
+        className={classes}
+        ref={initRipple}
+        {...otherProps}
+      >
+        {icon ? this.renderIcon() : null}
+        {children}
+      </button>
+    );
+  }
+
+  addClassesToElement(classes, element) {
+    const propsWithClasses = {
+      className: classnames(classes, element.props.className),
+    };
+    return React.cloneElement(element, propsWithClasses);
+  }
+
+  renderIcon() {
+    const {icon} = this.props;
+    return this.addClassesToElement('mdc-button__icon', icon);
+  }
+}
+
+Button.propTypes = {
+  raised: PropTypes.bool,
+  unelevated: PropTypes.bool,
+  stroked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  unbounded: PropTypes.bool,
+  initRipple: PropTypes.func,
+  className: PropTypes.string,
+  icon: PropTypes.element,
+  children: PropTypes.string,
+};
+
+Button.defaultProps = {
+  raised: false,
+  unelevated: false,
+  stroked: false,
+  disabled: false,
+  unbounded: false,
+  initRipple: () => {},
+  className: '',
+  icon: null,
+  children: '',
+};
+
+export default withRipple(Button);

--- a/frontend/src/vendor/react-material/card/ActionButtons.js
+++ b/frontend/src/vendor/react-material/card/ActionButtons.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default class ActionButtons extends React.Component {
+  addButtonClassToChildren = () => {
+    return React.Children.map(this.props.children, (item) => {
+      const className = classnames(
+        item.props.className, 'mdc-card__action', 'mdc-card__action--button');
+      const props = Object.assign({}, item.props, {className});
+      return React.cloneElement(item, props);
+    });
+  };
+
+  render() {
+    const {
+      className,
+      children, // eslint-disable-line no-unused-vars
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card__action-buttons', className);
+
+    return (
+      <div
+        className={classes}
+        {...otherProps}
+      >
+        {this.addButtonClassToChildren()}
+      </div>
+    );
+  }
+}
+
+ActionButtons.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+ActionButtons.defaultProps = {
+  className: '',
+  children: null,
+};

--- a/frontend/src/vendor/react-material/card/ActionIcons.js
+++ b/frontend/src/vendor/react-material/card/ActionIcons.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default class ActionIcons extends React.Component {
+  addIconClassToChildren = () => {
+    return React.Children.map(this.props.children, (item) => {
+      const className = classnames(
+        item.props.className, 'mdc-card__action', 'mdc-card__action--icon');
+      const props = Object.assign({}, item.props, {className});
+      return React.cloneElement(item, props);
+    });
+  };
+
+  render() {
+    const {
+      className,
+      children, // eslint-disable-line no-unused-vars
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card__action-icons', className);
+
+    return (
+      <div
+        className={classes}
+        {...otherProps}
+      >
+        {this.addIconClassToChildren()}
+      </div>
+    );
+  }
+}
+
+ActionIcons.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+ActionIcons.defaultProps = {
+  className: '',
+  children: null,
+};

--- a/frontend/src/vendor/react-material/card/Actions.js
+++ b/frontend/src/vendor/react-material/card/Actions.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default class Actions extends React.Component {
+
+  render() {
+    const {
+      className,
+      children,
+      fullBleed,
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card__actions', className, {
+      'mdc-card__actions--full-bleed': fullBleed,
+    });
+
+    return (
+      <div
+        className={classes}
+        {...otherProps}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+Actions.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  fullBleed: PropTypes.bool,
+};
+
+Actions.defaultProps = {
+  className: '',
+  children: null,
+  fullBleed: false,
+};

--- a/frontend/src/vendor/react-material/card/Media.js
+++ b/frontend/src/vendor/react-material/card/Media.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default class Media extends React.Component {
+  getStyles = () => {
+    const {imageUrl, style} = this.props;
+    return Object.assign({}, {
+      backgroundImage: `url(${imageUrl})`,
+    }, style);
+  }
+
+  render() {
+    const {
+      className,
+      children, // eslint-disable-line no-unused-vars
+      contentClassName, // eslint-disable-line no-unused-vars
+      square,
+      imageUrl, // eslint-disable-line no-unused-vars
+      style, // eslint-disable-line no-unused-vars
+      wide,
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card__media', className, {
+      'mdc-card__media--square': square,
+      'mdc-card__media--16-9': wide,
+    });
+
+    return (
+      <div
+        className={classes}
+        style={this.getStyles()}
+        {...otherProps}
+      >
+        {this.renderChildren()}
+      </div>
+    );
+  }
+
+  renderChildren() {
+    const {children, contentClassName} = this.props;
+    if (!children) {
+      return;
+    }
+
+    const classes = classnames('mdc-card__media-content', contentClassName);
+
+    return (
+      <div className={classes}>
+        {children}
+      </div>
+    );
+  }
+}
+
+Media.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  square: PropTypes.bool,
+  wide: PropTypes.bool,
+  contentClassName: PropTypes.string,
+  imageUrl: PropTypes.string,
+  style: PropTypes.object,
+};
+
+Media.defaultProps = {
+  className: '',
+  contentClassName: '',
+  children: null,
+  square: false,
+  wide: false,
+  imageUrl: '',
+  style: {},
+};

--- a/frontend/src/vendor/react-material/card/PrimaryContent.js
+++ b/frontend/src/vendor/react-material/card/PrimaryContent.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default class PrimaryContent extends React.Component {
+
+  render() {
+    const {
+      className,
+      children,
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card__primary-action', className);
+
+    return (
+      <div
+        className={classes}
+        {...otherProps}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+PrimaryContent.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+PrimaryContent.defaultProps = {
+  className: '',
+  children: null,
+};

--- a/frontend/src/vendor/react-material/card/index.js
+++ b/frontend/src/vendor/react-material/card/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import ActionButtons from './ActionButtons';
+import ActionIcons from './ActionIcons';
+import Actions from './Actions';
+import PrimaryContent from './PrimaryContent';
+import Media from './Media';
+
+export default class Card extends React.Component {
+  render() {
+    const {
+      className,
+      children,
+      stroked,
+      ...otherProps
+    } = this.props;
+    const classes = classnames('mdc-card', className, {
+      'mdc-card--stroked': stroked,
+    });
+
+    return (
+      <div
+        className={classes}
+        {...otherProps}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+Card.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  stroked: PropTypes.bool,
+};
+
+Card.defaultProps = {
+  children: null,
+  className: '',
+  stroked: false,
+};
+
+
+export {
+  ActionButtons as CardActionButtons,
+  ActionIcons as CardActionIcons,
+  Actions as CardActions,
+  PrimaryContent as CardPrimaryContent,
+  Media as CardMedia,
+};

--- a/frontend/src/vendor/react-material/fab/index.js
+++ b/frontend/src/vendor/react-material/fab/index.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import withRipple from '../ripple';
+
+export class Fab extends React.Component {
+
+  state = {
+    classList: new Set(),
+  };
+
+  get classes() {
+    const {classList} = this.state;
+    const {
+      mini,
+      className,
+    } = this.props;
+
+    return classnames('mdc-fab', Array.from(classList), className, {
+      'mdc-fab--mini': mini,
+    });
+  }
+
+  addIconClassToAllChildren = () => {
+    return React.Children.map(this.props.children, (item) => {
+      const className = `${item.props.className} mdc-fab__icon`;
+      const props = Object.assign({}, item.props, {className});
+      return React.cloneElement(item, props);
+    });
+  };
+
+  render() {
+    const {
+      /* eslint-disable */
+      children,
+      className,
+      unbounded,
+      mini,
+      /* eslint-enable */
+      initRipple,
+      ...otherProps
+    } = this.props;
+
+    return (
+        <button
+          className={this.classes}
+          ref={initRipple}
+          {...otherProps}>
+          {this.addIconClassToAllChildren()}
+        </button>
+    );
+  }
+}
+
+Fab.propTypes = {
+  mini: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element,
+  ]).isRequired,
+  initRipple: PropTypes.func,
+};
+
+Fab.defaultProps = {
+  mini: false,
+  className: '',
+  initRipple: () => {},
+};
+
+export default withRipple(Fab);

--- a/frontend/src/vendor/react-material/floating-label/index.js
+++ b/frontend/src/vendor/react-material/floating-label/index.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {MDCFloatingLabelFoundation} from '@material/floating-label';
+
+export default class FloatingLabel extends React.Component {
+
+  foundation_ = null;
+
+  constructor(props) {
+    super(props);
+    this.labelElement = React.createRef();
+  }
+
+  state = {
+    classList: new Set(),
+  };
+
+  componentDidMount() {
+    this.initializeFoundation();
+    this.handleWidthChange();
+
+    if (this.props.float) {
+      this.foundation_.float(true);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.float !== nextProps.float) {
+      this.foundation_.float(nextProps.float);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.children !== prevProps.children) {
+      this.handleWidthChange();
+    }
+  }
+
+  initializeFoundation = () => {
+    this.foundation_ = new MDCFloatingLabelFoundation(this.adapter);
+    this.foundation_.init();
+  }
+
+  get classes() {
+    const {classList} = this.state;
+    const {className} = this.props;
+    return classnames('mdc-floating-label', Array.from(classList), className);
+  }
+
+  get adapter() {
+    return {
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: this.removeClassFromClassList,
+    };
+  }
+
+  // must be called via ref
+  shake = () => {
+    this.foundation_.shake(true);
+  }
+
+  removeClassFromClassList = (className) => {
+    const {classList} = this.state;
+    classList.delete(className);
+    this.setState({classList});
+  }
+
+  handleWidthChange = () => {
+    const {handleWidthChange} = this.props;
+    if (this.labelElement.current) {
+      handleWidthChange(this.labelElement.current.offsetWidth);
+    }
+  }
+
+  onShakeEnd = () => {
+    const {LABEL_SHAKE} = MDCFloatingLabelFoundation.cssClasses;
+    this.removeClassFromClassList(LABEL_SHAKE);
+  }
+
+  render() {
+    const {
+      className, // eslint-disable-line no-unused-vars
+      children,
+      handleWidthChange, // eslint-disable-line no-unused-vars
+      float, // eslint-disable-line no-unused-vars
+      ...otherProps
+    } = this.props;
+
+    return (
+      <label
+        className={this.classes}
+        ref={this.labelElement}
+        onAnimationEnd={this.onShakeEnd}
+        {...otherProps}
+      >
+        {children}
+      </label>
+    );
+  }
+}
+
+FloatingLabel.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  handleWidthChange: PropTypes.func,
+  float: PropTypes.bool,
+};
+
+FloatingLabel.defaultProps = {
+  className: '',
+  handleWidthChange: () => {},
+  float: false,
+};

--- a/frontend/src/vendor/react-material/line-ripple/index.js
+++ b/frontend/src/vendor/react-material/line-ripple/index.js
@@ -1,0 +1,102 @@
+import React, {Component} from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import {MDCLineRippleFoundation} from '@material/line-ripple';
+
+export default class LineRipple extends Component {
+
+  foundation_ = null;
+
+  state = {
+    classList: new Set(),
+    style: {},
+  };
+
+  componentDidMount() {
+    this.foundation_ = new MDCLineRippleFoundation(this.adapter);
+    this.foundation_.init();
+    if (this.props.active) {
+      this.foundation_.activate();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.active !== nextProps.active) {
+      if (nextProps.active) {
+        this.foundation_.activate();
+      } else {
+        this.foundation_.deactivate();
+      }
+    }
+    if (this.props.rippleCenter !== nextProps.rippleCenter) {
+      this.foundation_.setRippleCenter(nextProps.rippleCenter);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  get adapter() {
+    return {
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: (className) => {
+        const {classList} = this.state;
+        classList.delete(className);
+        this.setState({classList});
+      },
+      hasClass: (className) => this.state.classList.has(className),
+      setStyle: this.setStyle,
+    };
+  }
+
+  get classes() {
+    const {className} = this.props;
+    const {classList} = this.state;
+    return classnames('mdc-line-ripple', Array.from(classList), className);
+  }
+
+  setStyle = (varName, value) => {
+    const updatedStyle = Object.assign({}, this.state.style);
+    updatedStyle[varName] = value;
+    this.setState({style: updatedStyle});
+  }
+
+  getMergedStyles = () => {
+    const {style: wrappedStyle} = this.props;
+    const {style} = this.state;
+    return Object.assign({}, style, wrappedStyle);
+  }
+
+  render() {
+    const {
+      style, // eslint-disable-line no-unused-vars
+      className, // eslint-disable-line no-unused-vars
+      active, // eslint-disable-line no-unused-vars
+      rippleCenter, // eslint-disable-line no-unused-vars
+      ...otherProps
+    } = this.props;
+    return (
+      <div
+        className={this.classes}
+        style={this.getMergedStyles()}
+        onTransitionEnd={(evt) => this.foundation_.handleTransitionEnd(evt)}
+        {...otherProps}></div>
+    );
+  }
+}
+
+LineRipple.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object,
+  active: PropTypes.bool,
+  rippleCenter: PropTypes.number,
+};
+
+LineRipple.defaultProps = {
+  className: '',
+  style: {},
+  active: false,
+  rippleCenter: 0,
+};

--- a/frontend/src/vendor/react-material/material-icon/index.js
+++ b/frontend/src/vendor/react-material/material-icon/index.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+import withRipple from '../ripple';
+
+export default class MaterialIcon extends React.Component {
+  render() {
+    const {
+      icon,
+      hasRipple,
+      ...otherProps
+    } = this.props;
+
+    if (hasRipple) {
+      return (
+        <RippleMaterialIcon
+          unbounded
+          hasRipple
+          icon={icon}
+          {...otherProps}
+        />
+      );
+    }
+
+    return (
+      <MaterialIconDefault
+        icon={icon}
+        {...otherProps}
+      />
+    );
+  }
+}
+
+const MaterialIconDefault = (props) => {
+  const {
+    className,
+    icon,
+    initRipple,
+    hasRipple,
+    ...otherProps
+  } = props;
+  const classes = classnames('material-icons', className, {
+    'material-icons--ripple-surface': hasRipple,
+  });
+
+  return (
+    <i
+      className={classes}
+      ref={initRipple}
+      {...otherProps}
+    >
+      {icon}
+    </i>
+  );
+};
+
+export const RippleMaterialIcon = withRipple(MaterialIconDefault);
+
+MaterialIcon.propTypes = {
+  icon: PropTypes.string,
+  hasRipple: PropTypes.bool,
+};
+
+MaterialIcon.defaultProps = {
+  icon: '',
+  hasRipple: false,
+};
+
+MaterialIconDefault.propTypes = {
+  icon: PropTypes.string,
+  className: PropTypes.string,
+  initRipple: PropTypes.func,
+  hasRipple: PropTypes.bool,
+};
+
+MaterialIconDefault.defaultProps = {
+  icon: '',
+  className: '',
+  initRipple: () => {},
+  hasRipple: false,
+};

--- a/frontend/src/vendor/react-material/notched-outline/index.js
+++ b/frontend/src/vendor/react-material/notched-outline/index.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {MDCNotchedOutlineFoundation} from '@material/notched-outline';
+
+export default class NotchedOutline extends React.Component {
+
+  foundation_ = null;
+
+  state = {
+    classList: new Set(),
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.outlineElement_ = React.createRef();
+    this.pathElement_ = React.createRef();
+    this.idleElement_ = React.createRef();
+  }
+
+  componentDidMount() {
+    this.foundation_ = new MDCNotchedOutlineFoundation(this.adapter);
+    this.foundation_.init();
+
+    const {notch, notchWidth, isRtl} = this.props;
+    if (notch) {
+      this.foundation_.notch(notchWidth, isRtl);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const hasToggledNotch = this.props.notch !== nextProps.notch;
+    const hasToggleRtl = this.props.isRtl !== nextProps.isRtl;
+    const notchWidthUpdated = this.props.notchWidth !== nextProps.notchWidth;
+    const shouldUpdateNotch = notchWidthUpdated || hasToggleRtl || hasToggledNotch;
+
+    if (!shouldUpdateNotch) {
+      return;
+    }
+
+    if (nextProps.notch) {
+      const {notchWidth, isRtl} = nextProps;
+      this.foundation_.notch(notchWidth, isRtl);
+    } else {
+      this.foundation_.closeNotch();
+    }
+  }
+
+  get classes() {
+    const {classList} = this.state;
+    const {className} = this.props;
+    return classnames('mdc-notched-outline', Array.from(classList), className);
+  }
+
+  get adapter() {
+    return {
+      getWidth: () => this.outlineElement_.current.offsetWidth,
+      getHeight: () => this.outlineElement_.current.offsetHeight,
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: (className) => {
+        const {classList} = this.state;
+        classList.delete(className);
+        this.setState({classList});
+      },
+      setOutlinePathAttr: (value) => this.pathElement_.current.setAttribute('d', value),
+      getIdleOutlineStyleValue: (propertyName) =>
+        window.getComputedStyle(this.idleElement_.current).getPropertyValue(propertyName),
+    };
+  }
+
+  render() {
+    return ([
+      <div
+        className={this.classes}
+        key='notched-outline'
+        ref={this.outlineElement_}>
+        <svg>
+          <path ref={this.pathElement_}
+            className='mdc-notched-outline__path' />
+        </svg>
+      </div>,
+      <div
+        ref={this.idleElement_}
+        className='mdc-notched-outline__idle'
+        key='notched-outline-idle'></div>,
+    ]);
+  }
+}
+
+NotchedOutline.propTypes = {
+  className: PropTypes.string,
+  isRtl: PropTypes.bool,
+  notch: PropTypes.bool,
+  notchWidth: PropTypes.number,
+};
+
+NotchedOutline.defaultProps = {
+  className: '',
+  isRtl: false,
+  notch: false,
+  notchWidth: 0,
+};

--- a/frontend/src/vendor/react-material/ripple/index.js
+++ b/frontend/src/vendor/react-material/ripple/index.js
@@ -1,0 +1,190 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import {MDCRippleFoundation, util} from '@material/ripple';
+
+const withRipple = (WrappedComponent) => {
+  class RippledComponent extends Component {
+
+    foundation_ = null;
+
+    state = {
+      classList: new Set(),
+      style: {},
+    };
+
+    componentDidMount() {
+      if (!this.foundation_) {
+        throw new Error('You must call initRipple from the element\'s ' +
+          'ref prop to initialize the adapter for withRipple');
+      }
+    }
+
+    componentWillUnmount() {
+      if (this.foundation_) {
+        this.foundation_.destroy();
+      }
+    }
+
+    initializeFoundation_ = (instance) => {
+      const adapter = this.createAdapter_(instance);
+      this.foundation_ = new MDCRippleFoundation(adapter);
+      this.foundation_.init();
+    }
+
+    createAdapter_ = (instance) => {
+      const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
+
+      return {
+        browserSupportsCssVars: () => util.supportsCssVariables(window),
+        isUnbounded: () => this.props.unbounded,
+        isSurfaceActive: () => instance[MATCHES](':active'),
+        isSurfaceDisabled: () => this.props.disabled,
+        addClass: (className) =>
+          this.setState({classList: this.state.classList.add(className)}),
+        removeClass: (className) => {
+          const {classList} = this.state;
+          classList.delete(className);
+          this.setState({classList});
+        },
+        registerDocumentInteractionHandler: (evtType, handler) =>
+          document.documentElement.addEventListener(evtType, handler, util.applyPassive()),
+        deregisterDocumentInteractionHandler: (evtType, handler) =>
+          document.documentElement.removeEventListener(evtType, handler, util.applyPassive()),
+        registerResizeHandler: (handler) => window.addEventListener('resize', handler),
+        deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
+        updateCssVariable: this.updateCssVariable,
+        computeBoundingRect: () => instance.getBoundingClientRect(),
+        getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset}),
+      };
+    }
+
+    get classes() {
+      const {className: wrappedCompClasses} = this.props;
+      const {classList} = this.state;
+      return classnames(Array.from(classList), wrappedCompClasses);
+    }
+
+    handleMouseDown = (e) => {
+      this.props.onMouseDown(e);
+      this.activateRipple(e);
+    }
+
+    handleMouseUp = (e) => {
+      this.props.onMouseUp(e);
+      this.deactivateRipple(e);
+    }
+
+    handleTouchStart = (e) => {
+      this.props.onTouchStart(e);
+      this.activateRipple(e);
+    }
+
+    handleTouchEnd = (e) => {
+      this.props.onTouchEnd(e);
+      this.deactivateRipple(e);
+    }
+
+    handleKeyDown = (e) => {
+      this.props.onKeyDown(e);
+      this.activateRipple(e);
+    }
+
+    handleKeyUp = (e) => {
+      this.props.onKeyUp(e);
+      this.deactivateRipple(e);
+    }
+
+    activateRipple = (e) => {
+      // https://reactjs.org/docs/events.html#event-pooling
+      e.persist();
+      requestAnimationFrame(() => {
+        this.foundation_.activate(e);
+      });
+    }
+
+    deactivateRipple = (e) => {
+      this.foundation_.deactivate(e);
+    }
+
+    updateCssVariable = (varName, value) => {
+      const updatedStyle = Object.assign({}, this.state.style);
+      updatedStyle[varName] = value;
+      this.setState({style: updatedStyle});
+    }
+
+    getMergedStyles = () => {
+      const {style: wrappedStyle} = this.props;
+      const {style} = this.state;
+      return Object.assign({}, style, wrappedStyle);
+    }
+
+    render() {
+      const {
+        /* start black list of otherprops */
+        /* eslint-disable */
+        unbounded,
+        style,
+        className,
+        onMouseDown,
+        onMouseUp,
+        onTouchStart,
+        onTouchEnd,
+        onKeyDown,
+        onKeyUp,
+        /* eslint-enable */
+        /* end black list of otherprops */
+        ...otherProps
+      } = this.props;
+
+      const updatedProps = Object.assign(otherProps, {
+        onMouseDown: this.handleMouseDown,
+        onMouseUp: this.handleMouseUp,
+        onTouchStart: this.handleTouchStart,
+        onTouchEnd: this.handleTouchEnd,
+        onKeyDown: this.handleKeyDown,
+        onKeyUp: this.handleKeyUp,
+        // call initRipple on ref on root element that needs ripple
+        initRipple: this.initializeFoundation_,
+        className: this.classes,
+        style: this.getMergedStyles(),
+      });
+
+      return <WrappedComponent {...updatedProps} />;
+    }
+  }
+
+  WrappedComponent.propTypes = Object.assign({
+    unbounded: PropTypes.bool,
+    disabled: PropTypes.bool,
+    style: PropTypes.object,
+    className: PropTypes.string,
+    onMouseDown: PropTypes.func,
+    onMouseUp: PropTypes.func,
+    onTouchStart: PropTypes.func,
+    onTouchEnd: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    onKeyUp: PropTypes.func,
+  }, WrappedComponent.propTypes);
+
+  WrappedComponent.defaultProps = Object.assign({
+    unbounded: false,
+    disabled: false,
+    style: {},
+    className: '',
+    onMouseDown: () => {},
+    onMouseUp: () => {},
+    onTouchStart: () => {},
+    onTouchEnd: () => {},
+    onKeyDown: () => {},
+    onKeyUp: () => {},
+  }, WrappedComponent.defaultProps);
+
+  RippledComponent.propTypes = WrappedComponent.propTypes;
+  RippledComponent.defaultProps = WrappedComponent.defaultProps;
+
+  return RippledComponent;
+};
+
+export default withRipple;

--- a/frontend/src/vendor/react-material/text-field/Input.js
+++ b/frontend/src/vendor/react-material/text-field/Input.js
@@ -1,0 +1,187 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+// whitelist based off of https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation
+// under section: `Validation-related attributes`
+const VALIDATION_ATTR_WHITELIST = [
+  'pattern', 'min', 'max', 'required', 'step', 'minlength', 'maxlength',
+];
+
+export default class Input extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputElement = React.createRef();
+  }
+
+  componentDidMount() {
+    this.props.handleValueChange(this.props.value);
+    if (this.props.id) {
+      this.props.setInputId(this.props.id);
+    }
+    if (this.props.disabled) {
+      this.props.setDisabled(true);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {foundation} = nextProps;
+    this.handleValidationAttributeUpdate(nextProps);
+
+    if (this.props.disabled !== nextProps.disabled) {
+      nextProps.setDisabled(nextProps.disabled);
+      foundation.setDisabled(nextProps.disabled);
+    }
+
+    if (this.props.id !== nextProps.id) {
+      nextProps.setInputId(nextProps.id);
+    }
+  }
+
+  get classes() {
+    return classnames('mdc-text-field__input', this.props.className);
+  }
+
+  handleFocus = (e) => {
+    const {foundation, handleFocusChange, onFocus} = this.props;
+    foundation.activateFocus();
+    handleFocusChange(true);
+    onFocus(e);
+  }
+
+  handleBlur = (e) => {
+    const {foundation, handleFocusChange, onBlur} = this.props;
+    foundation.deactivateFocus();
+    handleFocusChange(false);
+    onBlur(e);
+  }
+
+  handleMouseDown = (e) => {
+    const {foundation, onMouseDown} = this.props;
+    foundation.setTransformOrigin(e);
+    onMouseDown(e);
+  }
+
+  handleTouchStart = (e) => {
+    const {foundation, onTouchStart} = this.props;
+    foundation.setTransformOrigin(e);
+    onTouchStart(e);
+  }
+
+  // To stay in sync with the MDC React Text Field Component, handleValueChange()
+  // is called to update MDC React Text Field's state. That state variable
+  // is used to let other subcomponents and the foundation know what the current
+  // value of the input is.
+  handleChange = (e) => {
+    const {foundation, handleValueChange, onChange} = this.props;
+    const {value} = e.target;
+
+    foundation.autoCompleteFocus();
+    handleValueChange(value);
+    onChange(e);
+  }
+
+  handleValidationAttributeUpdate = (nextProps) => {
+    const {foundation} = nextProps;
+    VALIDATION_ATTR_WHITELIST.some((attr) => {
+      if (this.props[attr] !== nextProps[attr]) {
+        // TODO: Update this when issue is fixed:
+        // https://github.com/material-components/material-components-web/issues/2716
+        foundation.handleValidationAttributeMutation_([{
+          // TODO: Update this when issue is fixed:
+          // https://github.com/material-components/material-components-web/issues/2717
+          attributeName: VALIDATION_ATTR_WHITELIST[0],
+        }]);
+        return true;
+      }
+    });
+  }
+
+  isBadInput = () => this.inputElement.current.validity.badInput;
+  isValid = () => this.inputElement.current.validity.valid;
+
+  render() {
+    const {
+      disabled,
+      /* eslint-disable no-unused-vars */
+      className,
+      foundation,
+      value,
+      handleFocusChange,
+      handleValueChange,
+      setDisabled,
+      setInputId,
+      onFocus,
+      onBlur,
+      onMouseDown,
+      onTouchStart,
+      onChange,
+      /* eslint-enable no-unused-vars */
+      ...otherProps
+    } = this.props;
+    return (
+      <input
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
+        onMouseDown={this.handleMouseDown}
+        onTouchStart={this.handleTouchStart}
+        onChange={this.handleChange}
+        disabled={disabled}
+        value={value}
+        ref={this.inputElement}
+        className={this.classes}
+        {...otherProps}
+      />
+    );
+  }
+}
+
+Input.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  foundation: PropTypes.shape({
+    activateFocus: PropTypes.func,
+    deactivateFocus: PropTypes.func,
+    autoCompleteFocus: PropTypes.func,
+    setTransformOrigin: PropTypes.func,
+    setTransformOrigin: PropTypes.func,
+    handleValidationAttributeMutation_: PropTypes.func,
+  }),
+  handleValueChange: PropTypes.func,
+  id: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onTouchStart: PropTypes.func,
+  setDisabled: PropTypes.func,
+  setInputId: PropTypes.func,
+  handleFocusChange: PropTypes.func,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+};
+
+Input.defaultProps = {
+  className: '',
+  disabled: false,
+  foundation: {
+    activateFocus: () => {},
+    deactivateFocus: () => {},
+    autoCompleteFocus: () => {},
+    setTransformOrigin: () => {},
+    handleValidationAttributeMutation_: () => {},
+  },
+  handleValueChange: () => {},
+  id: null,
+  onBlur: () => {},
+  onChange: () => {},
+  onFocus: () => {},
+  onMouseDown: () => {},
+  onTouchStart: () => {},
+  setDisabled: () => {},
+  setInputId: () => {},
+  handleFocusChange: () => {},
+  value: '',
+};

--- a/frontend/src/vendor/react-material/text-field/helper-text/index.js
+++ b/frontend/src/vendor/react-material/text-field/helper-text/index.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {MDCTextFieldHelperTextFoundation} from '@material/textfield';
+
+export default class HelperText extends React.Component {
+
+  foundation_ = null;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      'aria-hidden': props['aria-hidden'],
+      'role': props.role,
+      'classList': new Set(),
+    };
+  }
+
+  componentDidMount() {
+    this.foundation_ = new MDCTextFieldHelperTextFoundation(this.adapter);
+    this.foundation_.init();
+
+    if (this.props.showToScreenReader) {
+      this.foundation_.showToScreenReader(true);
+    }
+    if (!this.props.isValid) {
+      this.foundation_.setValidity(false);
+    }
+    if (this.props.isValidationMessage) {
+      this.foundation_.setValidation(true);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.showToScreenReader !== nextProps.showToScreenReader) {
+      this.foundation_.showToScreenReader(nextProps.showToScreenReader);
+    }
+    if (this.props.isValid !== nextProps.isValid) {
+      this.foundation_.setValidity(nextProps.isValid);
+    }
+    if (this.props.isValidationMessage !== nextProps.isValidationMessage) {
+      this.foundation_.setValidation(nextProps.isValidationMessage);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  get classes() {
+    const {className, persistent, validation} = this.props;
+
+    return classnames('mdc-text-field-helper-text', className, {
+      'mdc-text-field-helper-text--persistent': persistent,
+      'mdc-text-field-helper-text--validation-msg': validation,
+    });
+  }
+
+  get adapter() {
+    return {
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: (className) => {
+        const {classList} = this.state;
+        classList.delete(className);
+        this.setState({classList});
+      },
+      hasClass: (className) => this.classes.split(' ').includes(className),
+      setAttr: (attr, value) => this.setState({[attr]: value}),
+      removeAttr: (attr) => this.setState({[attr]: null}),
+    };
+  }
+
+  render() {
+    return (
+      <p
+        className={this.classes}
+        role={this.state.role}
+        aria-hidden={this.state['aria-hidden']}
+      >
+        {this.props.children}
+      </p>
+    );
+  }
+}
+
+HelperText.propTypes = {
+  'aria-hidden': PropTypes.bool,
+  'children': PropTypes.node,
+  'className': PropTypes.string,
+  'isValid': PropTypes.bool,
+  'isValidationMessage': PropTypes.bool,
+  'persistent': PropTypes.bool,
+  'role': PropTypes.string,
+  'showToScreenReader': PropTypes.bool,
+  'validation': PropTypes.bool,
+};
+
+HelperText.defaultProps = {
+  'aria-hidden': false,
+  'children': null,
+  'className': '',
+  'isValid': true,
+  'isValidationMessage': false,
+  'persistent': false,
+  'role': null,
+  'showToScreenReader': false,
+  'validation': false,
+};

--- a/frontend/src/vendor/react-material/text-field/icon/index.js
+++ b/frontend/src/vendor/react-material/text-field/icon/index.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {MDCTextFieldIconFoundation} from '@material/textfield';
+
+export default class Icon extends React.Component {
+
+  foundation_ = null;
+
+  constructor(props) {
+    super(props);
+    const {
+      tabIndex: tabindex, // note that foundation.js alters tabindex not tabIndex
+      role,
+    } = props.children.props;
+
+    this.state = {
+      tabindex,
+      role,
+    };
+  }
+
+  componentDidMount() {
+    this.foundation_ = new MDCTextFieldIconFoundation(this.adapter);
+    this.foundation_.init();
+    if (this.props.disabled) {
+      this.foundation_.setDisabled(true);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.disabled !== nextProps.disabled) {
+      this.foundation_.setDisabled(nextProps.disabled);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  get adapter() {
+    return {
+      getAttr: (attr) => this.state[attr],
+      setAttr: (attr, value) => this.setState({[attr]: value}),
+      removeAttr: (attr) => this.setState({[attr]: null}),
+    };
+  }
+
+  addIconAttrsToChildren = () => {
+    const {tabindex: tabIndex, role} = this.state;
+    const child = React.Children.only(this.props.children);
+    const className = classnames('mdc-text-field__icon', child.props.className);
+    const props = Object.assign({}, child.props, {
+      className, tabIndex, role,
+    });
+    return React.cloneElement(child, props);
+  }
+
+  render() {
+    return this.addIconAttrsToChildren();
+  }
+}
+
+Icon.propTypes = {
+  children: PropTypes.element.isRequired,
+  disabled: PropTypes.bool,
+};
+
+Icon.defaultProps = {
+  disabled: false,
+};

--- a/frontend/src/vendor/react-material/text-field/index.js
+++ b/frontend/src/vendor/react-material/text-field/index.js
@@ -1,0 +1,350 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {MDCTextFieldFoundation} from '@material/textfield';
+
+import Input from './Input';
+import Icon from './icon';
+import HelperText from './helper-text';
+import FloatingLabel from '@material/react-floating-label';
+import LineRipple from '@material/react-line-ripple';
+import NotchedOutline from '@material/react-notched-outline';
+
+class TextField extends React.Component {
+
+  foundation_ = null;
+
+  constructor(props) {
+    super(props);
+    this.floatingLabelElement = React.createRef();
+    this.inputElement = React.createRef();
+    this.textFieldElement = React.createRef();
+
+    this.state = {
+      // line ripple state
+      activeLineRipple: false,
+
+      // root state
+      value: null,
+      classList: new Set(),
+      inputId: props.children.props.id,
+      isFocused: false,
+      dir: 'ltr',
+      disabled: false,
+
+      // floating label state
+      labelIsFloated: false,
+      labelWidth: 0,
+
+      // line ripple state
+      lineRippleCenter: null,
+
+      // notched outline state
+      outlineIsNotched: false,
+
+      // helper text state
+      showHelperTextToScreenReader: false,
+      isValid: true,
+    };
+  }
+
+  componentDidMount() {
+    const foundationMap = {
+      helperText: this.helperTextAdapter,
+    };
+    this.foundation_ = new MDCTextFieldFoundation(this.adapter, foundationMap);
+    this.foundation_.init();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.value !== prevState.value) {
+      this.foundation_.setValue(this.state.value);
+    }
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  /**
+  * getters
+  */
+
+  get classes() {
+    const {classList, disabled} = this.state;
+    const {className, box, dense, outlined, fullWidth, textarea, trailingIcon, leadingIcon} = this.props;
+    return classnames('mdc-text-field', Array.from(classList), className, {
+      'mdc-text-field--outlined': outlined,
+      'mdc-text-field--textarea': textarea,
+      'mdc-text-field--fullwidth': fullWidth,
+      'mdc-text-field--disabled': disabled,
+      'mdc-text-field--with-trailing-icon': trailingIcon,
+      'mdc-text-field--with-leading-icon': leadingIcon,
+      'mdc-text-field--box': box,
+      'mdc-text-field--dense': dense,
+    });
+  }
+
+  get adapter() {
+    const rootAdapterMethods = {
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: (className) => {
+        const {classList} = this.state;
+        classList.delete(className);
+        this.setState({classList});
+      },
+      hasClass: (className) => this.classes.split(' ').includes(className),
+      isFocused: () => this.state.isFocused,
+      isRtl: this.getIsRtl,
+    };
+
+    return Object.assign({},
+      rootAdapterMethods,
+      this.inputAdapter,
+      this.labelAdapter,
+      this.lineRippleAdapter,
+      this.notchedOutlineAdapter,
+    );
+  }
+
+  get inputAdapter() {
+    // For reference: This is the shape of what the vanilla component `getNativeInput` returns
+    // {
+    //  value: string,
+    //  disabled: boolean, --> doesn't need to be implemented since the <INPUT> handles it
+    //  also the `get disabled` isn't actually used, except in the vanilla component
+    //  validity: {
+    //    badInput: boolean,
+    //    valid: boolean,
+    //  },
+    // }
+
+    return {
+      getNativeInput: () => {
+        let badInput;
+        let valid;
+        if (this.inputElement && this.inputElement.current) {
+          badInput = this.inputElement.current.isBadInput();
+          valid = this.inputElement.current.isValid();
+        }
+        const input = {
+          validity: {badInput, valid},
+        };
+
+        // https://stackoverflow.com/a/44913378
+        Object.defineProperty(input, 'value', {
+          get: () => this.state.value,
+          // set value doesn't need to be done, since value is set via <Input>
+          // needs setter here so it browser doesn't throw error
+          set: () => {},
+        });
+
+        return input;
+      },
+    };
+  }
+
+  get labelAdapter() {
+    return {
+      shakeLabel: (shakeLabel) => {
+        const {floatingLabelElement: floatingLabel} = this;
+        if (!shakeLabel) return;
+        if (floatingLabel && floatingLabel.current) {
+          floatingLabel.current.shake();
+        }
+      },
+      floatLabel: (labelIsFloated) => this.setState({labelIsFloated}),
+      hasLabel: () => !!this.props.label,
+      getLabelWidth: () => this.state.labelWidth,
+    };
+  }
+
+  get lineRippleAdapter() {
+    return {
+      activateLineRipple: () => this.setState({activeLineRipple: true}),
+      deactivateLineRipple: () => this.setState({activeLineRipple: false}),
+      setLineRippleTransformOrigin: (lineRippleCenter) => this.setState({lineRippleCenter}),
+    };
+  }
+
+  get notchedOutlineAdapter() {
+    return {
+      notchOutline: () => this.setState({outlineIsNotched: true}),
+      closeOutline: () => this.setState({outlineIsNotched: false}),
+      hasOutline: () => !!this.props.outlined,
+    };
+  }
+
+  get helperTextAdapter() {
+    return {
+      showToScreenReader: () =>
+        this.setState({showHelperTextToScreenReader: true}),
+      setValidity: (isValid) => this.setState({isValid}),
+    };
+  }
+
+  getIsRtl = () => {
+    if (this.textFieldElement.current) {
+      const dir = window.getComputedStyle(this.textFieldElement.current).getPropertyValue('direction');
+      return dir === 'rtl';
+    }
+  }
+
+  inputProps(props) {
+    return Object.assign({}, props, {
+      foundation: this.foundation_,
+      handleFocusChange: (isFocused) => this.setState({isFocused}),
+      handleValueChange: (value) => this.setState({value}),
+      setDisabled: (disabled) => this.setState({disabled}),
+      setInputId: (id) => this.setState({inputId: id}),
+      ref: this.inputElement,
+    });
+  }
+
+  /**
+  * render methods
+  */
+
+  render() {
+    const {
+      label,
+      fullWidth,
+      helperText,
+      outlined,
+      leadingIcon,
+      trailingIcon,
+      textarea,
+    } = this.props;
+
+    const textField = (
+      <div
+        className={this.classes}
+        onClick={() => this.foundation_ && this.foundation_.handleTextFieldInteraction()}
+        onKeyDown={() => this.foundation_ && this.foundation_.handleTextFieldInteraction()}
+        key='text-field-container'
+        ref={this.textFieldElement}
+      >
+        {leadingIcon ? this.renderIcon(leadingIcon) : null}
+        {this.renderInput()}
+        {label && !fullWidth ? this.renderLabel() : null}
+        {outlined ? this.renderNotchedOutline() : null}
+        {!fullWidth && !textarea && !outlined ? this.renderLineRipple() : null}
+        {trailingIcon ? this.renderIcon(trailingIcon) : null}
+      </div>
+    );
+
+    if (helperText) {
+      return ([
+        textField, this.renderHelperText(),
+      ]);
+    }
+    return textField;
+  }
+
+  renderInput() {
+    const child = React.Children.only(this.props.children);
+    const props = this.inputProps(child.props);
+    return React.cloneElement(child, props);
+  }
+
+  renderLabel() {
+    const {label, floatingLabelClassName} = this.props;
+    const {inputId} = this.state;
+    return (
+      <FloatingLabel
+        className={floatingLabelClassName}
+        float={this.state.labelIsFloated}
+        handleWidthChange={
+          (labelWidth) => this.setState({labelWidth})}
+        ref={this.floatingLabelElement}
+        htmlFor={inputId}
+      >
+        {label}
+      </FloatingLabel>
+    );
+  }
+
+  renderLineRipple() {
+    const {lineRippleClassName} = this.props;
+    const {activeLineRipple, lineRippleCenter} = this.state;
+    return (
+      <LineRipple
+        rippleCenter={lineRippleCenter}
+        className={lineRippleClassName}
+        active={activeLineRipple}
+      />
+    );
+  }
+
+  renderNotchedOutline() {
+    const {notchedOutlineClassName} = this.props;
+    const {outlineIsNotched, labelWidth} = this.state;
+    return (
+      <NotchedOutline
+        className={notchedOutlineClassName}
+        isRtl={this.getIsRtl()}
+        notch={outlineIsNotched}
+        notchWidth={labelWidth}
+      />
+    );
+  }
+
+  renderHelperText() {
+    const {helperText} = this.props;
+    const {isValid, showHelperTextToScreenReader: showToScreenReader} = this.state;
+    const props = Object.assign({
+      showToScreenReader,
+      isValid,
+      key: 'text-field-helper-text',
+    }, helperText.props);
+    return React.cloneElement(helperText, props);
+  }
+
+  renderIcon(icon) {
+    const {disabled} = this.state;
+    // Toggling disabled will trigger icon.foundation.setDisabled()
+    return (
+      <Icon disabled={disabled}>
+        {icon}
+      </Icon>
+    );
+  }
+}
+
+TextField.propTypes = {
+  'box': PropTypes.bool,
+  'children.props': PropTypes.shape(Input.propTypes),
+  'children': PropTypes.element,
+  'className': PropTypes.string,
+  'dense': PropTypes.bool,
+  'floatingLabelClassName': PropTypes.string,
+  'fullWidth': PropTypes.bool,
+  'helperText': PropTypes.element,
+  'label': PropTypes.string.isRequired,
+  'leadingIcon': PropTypes.element,
+  'lineRippleClassName': PropTypes.string,
+  'notchedOutlineClassName': PropTypes.string,
+  'outlined': PropTypes.bool,
+  'textarea': PropTypes.bool,
+  'trailingIcon': PropTypes.element,
+};
+
+TextField.defaultProps = {
+  box: false,
+  className: '',
+  dense: false,
+  floatingLabelClassName: '',
+  fullWidth: false,
+  helperText: null,
+  leadingIcon: null,
+  lineRippleClassName: '',
+  notchedOutlineClassName: '',
+  outlined: false,
+  textarea: false,
+  trailingIcon: null,
+};
+
+
+export {HelperText, Input};
+export default TextField;

--- a/frontend/src/vendor/react-material/top-app-bar/index.js
+++ b/frontend/src/vendor/react-material/top-app-bar/index.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {
+  MDCTopAppBarFoundation,
+  MDCShortTopAppBarFoundation,
+} from '@material/top-app-bar';
+
+export default class TopAppBar extends React.Component {
+
+  foundation_ = null;
+
+  state = {
+    classList: new Set(),
+  };
+
+  get classes() {
+    const {classList} = this.state;
+    const {
+      shortCollapsed,
+      className,
+      short,
+      prominent,
+    } = this.props;
+
+    return classnames('mdc-top-app-bar', Array.from(classList), className, {
+      'mdc-top-app-bar--short': shortCollapsed || short,
+      'mdc-top-app-bar--short-collapsed': shortCollapsed,
+      'mdc-top-app-bar--prominent': prominent,
+    });
+  }
+
+  componentDidMount() {
+    this.initializeFoundation();
+  }
+
+  componentWillUnmount() {
+    this.foundation_.destroy();
+  }
+
+  initializeFoundation = () => {
+    if (this.props.short) {
+      this.foundation_ = new MDCShortTopAppBarFoundation(this.adapter);
+    } else {
+      this.foundation_ = new MDCTopAppBarFoundation(this.adapter);
+    }
+
+    this.foundation_.init();
+  }
+
+  addClassesToElement(classes, element) {
+    const updatedProps = {
+      className: classnames(classes, element.props.className),
+    };
+    return React.cloneElement(element, updatedProps);
+  }
+
+  enableRippleOnElement(element) {
+    // If `element` is a Native React Element, throw error to enforce
+    // ripple
+    if (typeof element.type === 'string') {
+      const errorText = 'Material Design requires all Top App Bar Icons to ' +
+        'have ripple. Please use ../react-ripple HOC with your icons.';
+      throw new Error(errorText);
+    }
+
+    return React.cloneElement(element, {hasRipple: true});
+  }
+
+  get adapter() {
+    const {actionItems} = this.props;
+
+    return {
+      addClass: (className) =>
+        this.setState({classList: this.state.classList.add(className)}),
+      removeClass: (className) => {
+        const {classList} = this.state;
+        classList.delete(className);
+        this.setState({classList});
+      },
+      hasClass: (className) => this.classes.split(' ').includes(className),
+      registerScrollHandler: (handler) =>
+        window.addEventListener('scroll', handler),
+      deregisterScrollHandler: (handler) =>
+        window.removeEventListener('scroll', handler),
+      getViewportScrollY: () => window.pageYOffset,
+      getTotalActionItems: () => !!(actionItems && actionItems.length),
+    };
+  }
+
+  render() {
+    return (
+      <header className={this.classes}>
+        <div className='mdc-top-app-bar__row'>
+          {this.renderTitleAndNavigationSection()}
+          {this.renderActionItems()}
+        </div>
+      </header>
+    );
+  }
+
+  renderTitleAndNavigationSection() {
+    const {title} = this.props;
+    const classes =
+      'mdc-top-app-bar__section mdc-top-app-bar__section--align-start';
+
+    return (
+      <section className={classes}>
+        {this.renderNavigationIcon()}
+        <span className="mdc-top-app-bar__title">
+          {title}
+        </span>
+      </section>
+    );
+  }
+
+  renderNavigationIcon() {
+    const {navigationIcon} = this.props;
+
+    if (!navigationIcon) {
+      return;
+    }
+
+    const elementWithClasses = this.addClassesToElement('mdc-top-app-bar__navigation-icon', navigationIcon);
+    return this.enableRippleOnElement(elementWithClasses);
+  }
+
+  renderActionItems() {
+    const {actionItems} = this.props;
+    if (!actionItems) {
+      return;
+    }
+
+    return (
+      <section
+        className='mdc-top-app-bar__section mdc-top-app-bar__section--align-end'
+        role='toolbar'
+      >
+        {/* to set key on the element, the element needs to be cloned */}
+        {actionItems.map((item, key) => {
+          const elementWithClasses = this.addClassesToElement(
+            'mdc-top-app-bar__action-item', item);
+          const elementWithRipple = this.enableRippleOnElement(elementWithClasses);
+          return React.cloneElement(elementWithRipple, {key});
+        })}
+      </section>
+    );
+  }
+
+}
+
+TopAppBar.propTypes = {
+  shortCollapsed: PropTypes.bool,
+  short: PropTypes.bool,
+  prominent: PropTypes.bool,
+  title: PropTypes.string,
+  actionItems: PropTypes.arrayOf(PropTypes.element),
+  navigationIcon: PropTypes.element,
+  className: PropTypes.string,
+};
+
+TopAppBar.defaultProps = {
+  shortCollapsed: false,
+  short: false,
+  prominent: false,
+  title: '',
+  actionItems: null,
+  navigationIcon: null,
+  className: '',
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16,9 +16,20 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@material/animation@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.34.0.tgz#a99cc9dabf7d0179b4da9a0aaa1575c4d1513823"
+
 "@material/base@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.35.0.tgz#8640c2da385e8cc393ff56153c5a319f5a7704cb"
+
+"@material/elevation@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.35.0.tgz#a0b8bbe346ebb29a4decd35b961aaf2635ff89bd"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/theme" "^0.4.0"
 
 "@material/ripple@^0.35.0":
   version "0.35.0"
@@ -27,9 +38,33 @@
     "@material/base" "^0.35.0"
     "@material/theme" "^0.35.0"
 
+"@material/rtl@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.35.0.tgz#caae659e35a9bf1b9d91c734c8a3315a81bcde21"
+
 "@material/theme@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.35.0.tgz#a2c76f60b82a53d399b769ef91ec52e83ad3c3bd"
+
+"@material/theme@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.4.0.tgz#0aef1a0279b65c15990584fb8b8eca095c734641"
+
+"@material/top-app-bar@^0.35.2":
+  version "0.35.2"
+  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-0.35.2.tgz#7c3f48e01cecb00f6857e8f8d1047dee01d52561"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/base" "^0.35.0"
+    "@material/elevation" "^0.35.0"
+    "@material/ripple" "^0.35.0"
+    "@material/rtl" "^0.35.0"
+    "@material/theme" "^0.35.0"
+    "@material/typography" "^0.35.0"
+
+"@material/typography@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.35.0.tgz#23ad7eb7c9789e69c7c3fa54df8fc311cd7fc4b1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -305,6 +305,10 @@
     react-split-pane "^0.1.77"
     react-treebeard "^2.1.0"
 
+"@types/classnames@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.3.tgz#3f0ff6873da793870e20a260cada55982f38a9e5"
+
 "@types/jest@22.2.3":
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16,6 +16,21 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@material/base@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.35.0.tgz#8640c2da385e8cc393ff56153c5a319f5a7704cb"
+
+"@material/ripple@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.35.0.tgz#3670e04e02dd6efc1ff0546e5129b4e96ec55f70"
+  dependencies:
+    "@material/base" "^0.35.0"
+    "@material/theme" "^0.35.0"
+
+"@material/theme@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.35.0.tgz#a2c76f60b82a53d399b769ef91ec52e83ad3c3bd"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
As discussed with @fedriz and maybe others, we are trying to use the new [material design library](https://material.io/develop/), there are some issues with the [react library](https://github.com/material-components/material-components-web-react) so for now the idea is to vendorise the packages and use them directly with the material components web css.

Issues:

- We need to manually sync the packages when there's an update
- We are including the whole material design css
- We can use theming

All these issues will be fixed when the react library will be in a beta or production stage, hopefully this will be soon enough, but for now I guess having the components in our repo is not too bad