### PR TITLE
Bump `pylint-django` to 2.0.5

### DIFF
--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 pylint==2.1.1
-pylint-django==2.0.2
+pylint-django==2.0.5
 pytest==3.8.0
 pytest-cov==2.6.0
 pytest-django==3.4.3


### PR DESCRIPTION
Fixes 
```   
from astroid.bases import YES, Instance
ImportError: cannot import name YES
```