### PR TITLE
Refactor code to fix pylint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,6 @@ jobs:
             cd backend
             py.test --cov-report xml --cov=. --cov-fail-under 100
 
-      - run:
-          name: upload codacy report
-          command: |
-            . venv/bin/activate
-            cd backend
-            python-codacy-coverage -r coverage.xml
-          environment:
-            CODACY_PROJECT_TOKEN: b371fba19b824c62ad6270d4e1f3b410
-
   backend-schema:
     docker:
       - image: circleci/python:3.6.5@sha256:5ed7f0d14f10f5b81c012c6011969ca5abf9f7bc53e0448844aa9274a359178e

--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -130,7 +130,9 @@ disable=print-statement,
         missing-docstring,
         invalid-name,
         no-self-use,
-        unused-argument
+        unused-argument,
+        too-few-public-methods,
+        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -521,7 +523,7 @@ max-branches=12
 max-locals=15
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=15
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20

--- a/backend/api/forms.py
+++ b/backend/api/forms.py
@@ -10,7 +10,7 @@ class ContextAwareForm(forms.ModelForm):
     :py:class:`api.mutations.ContextAwareDjangoModelFormMutation` (or subclasses)
     and want to access the request object using `self.context`.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # pylint: disable=return-in-init
         self._context = kwargs.pop('context', None)
         return super().__init__(*args, **kwargs)
 

--- a/backend/api/mutations.py
+++ b/backend/api/mutations.py
@@ -15,8 +15,8 @@ class ContextAwareDjangoModelFormMutation(mutation.DjangoModelFormMutation):
         abstract = True
 
     @classmethod
-    def get_form_kwargs(cls, root, info, **input):
-        kwargs = super().get_form_kwargs(root, info, **input)
+    def get_form_kwargs(cls, root, info, **input_):
+        kwargs = super().get_form_kwargs(root, info, **input_)
         kwargs['context'] = info.context
         return kwargs
 
@@ -36,8 +36,8 @@ class AuthOnlyDjangoFormMutation(ContextAwareDjangoModelFormMutation):
         abstract = True
 
     @classmethod
-    def mutate_and_get_payload(cls, root, info, **input):
+    def mutate_and_get_payload(cls, root, info, **input_):
         if not info.context.user.is_authenticated:
             raise GraphQLError('User not logged in')
 
-        return super().mutate_and_get_payload(root, info, **input)
+        return super().mutate_and_get_payload(root, info, **input_)

--- a/backend/conferences/models/conference.py
+++ b/backend/conferences/models/conference.py
@@ -16,8 +16,14 @@ class Conference(TimeFramedModel, TimeStampedModel):
 
     topics = models.ManyToManyField('conferences.Topic', verbose_name=_('topics'))
     languages = models.ManyToManyField('languages.Language', verbose_name=_('languages'))
-    audience_levels = models.ManyToManyField('conferences.AudienceLevel', verbose_name=_('audience levels'))
-    submission_types = models.ManyToManyField('submissions.SubmissionType', verbose_name=_('submission types'))
+    audience_levels = models.ManyToManyField(
+        'conferences.AudienceLevel',
+        verbose_name=_('audience levels')
+    )
+    submission_types = models.ManyToManyField(
+        'submissions.SubmissionType',
+        verbose_name=_('submission types')
+    )
 
     @property
     def is_cfp_open(self):

--- a/backend/conferences/models/deadline.py
+++ b/backend/conferences/models/deadline.py
@@ -31,7 +31,10 @@ class Deadline(TimeFramedModel):
             raise exceptions.ValidationError(_('Start date cannot be after end'))
 
         if self.type != Deadline.TYPES.custom:
-            if Deadline.objects.filter(conference=self.conference, type=self.type).exclude(id=self.id).exists():
+            if Deadline.objects.filter(
+                    conference=self.conference,
+                    type=self.type
+                ).exclude(id=self.id).exists():
                 raise exceptions.ValidationError(
                     _('You can only have one deadline of type %(type)s') % {'type': self.type}
                 )

--- a/backend/conferences/models/deadline.py
+++ b/backend/conferences/models/deadline.py
@@ -34,7 +34,7 @@ class Deadline(TimeFramedModel):
             if Deadline.objects.filter(
                     conference=self.conference,
                     type=self.type
-                ).exclude(id=self.id).exists():
+            ).exclude(id=self.id).exists():
                 raise exceptions.ValidationError(
                     _('You can only have one deadline of type %(type)s') % {'type': self.type}
                 )

--- a/backend/conferences/models/ticket.py
+++ b/backend/conferences/models/ticket.py
@@ -6,7 +6,12 @@ from model_utils.models import TimeFramedModel, TimeStampedModel
 
 
 class Ticket(TimeFramedModel, TimeStampedModel):
-    conference = models.ForeignKey('conferences.Conference', on_delete=models.CASCADE, verbose_name=_('conference'), related_name='tickets')
+    conference = models.ForeignKey(
+        'conferences.Conference',
+        on_delete=models.CASCADE,
+        verbose_name=_('conference'),
+        related_name='tickets'
+    )
 
     code = models.CharField(_('code'), max_length=10)
     name = models.CharField(_('name'), max_length=100)

--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -6,6 +6,5 @@ pytest==3.8.0
 pytest-cov==2.6.1
 pytest-django==3.4.7
 pytest-pylint==0.14.0
-codacy-coverage==1.3.11
 pytest-factoryboy==2.0.2
 factory-boy==2.11.1

--- a/backend/users/schema.py
+++ b/backend/users/schema.py
@@ -11,5 +11,5 @@ class UsersQuery:
     def resolve_me(self, info):
         if not info.context.user.is_authenticated:
             raise GraphQLError("User not logged in")
-        else:
-            return info.context.user
+
+        return info.context.user

--- a/backend/users/types.py
+++ b/backend/users/types.py
@@ -1,6 +1,6 @@
-from .models import User
-
 from graphene_django import DjangoObjectType
+
+from .models import User
 
 
 class MeUserType(DjangoObjectType):


### PR DESCRIPTION
I fixed all the issues that `pylint` reported.

The changes I did to the configuration:

- Increased `max-parents` to 15, we cannot do much here, sometimes you can reach that limit even with a simple django view, so I increased it
- Disabled `too-few-public-methods` because we have the graphql types that do not have any public method
- Disabled `no-member` because pylint is not able to understand Grahene well (so it thinks that `self.[field]` is `graphene.NonNull` instead of the model instance. Would love to fix this problem without disabling this rule as it's actually very useful
