### PR TITLE
Fix failing frontend lint

### DIFF
--- a/frontend/src/components/schedule-table/index.tsx
+++ b/frontend/src/components/schedule-table/index.tsx
@@ -11,7 +11,6 @@ type Props = {
 
 export const ScheduleTable = (props: Props) => {
   const schedule = props.schedule;
-  console.log('schedule:', schedule);
   return (
     <div>
       <h2>
@@ -21,7 +20,7 @@ export const ScheduleTable = (props: Props) => {
         const group = schedule.schedule[groupId];
         const firstItem = group.items[0];
         const dateFirstItem = new Date(firstItem.start);
-        console.log('group', group);
+
         return (
           <div>
             <h3>Group #{groupId}</h3>

--- a/frontend/src/pages/schedule/index.tsx
+++ b/frontend/src/pages/schedule/index.tsx
@@ -1,18 +1,14 @@
-import * as React from 'react';
 import { RouteComponentProps } from '@reach/router';
-
+import * as React from 'react';
+import { Query } from 'react-apollo';
+import { ScheduleTable } from '../../components/schedule-table/index';
+import SCHEDULE from './query.graphql';
+import * as styles from './style.css';
 import {
   Schedule as ScheduleType,
-  Schedule_conference_schedule,
   ScheduleVariables,
+  Schedule_conference_schedule,
 } from './types/Schedule';
-
-import { Query } from 'react-apollo';
-
-import SCHEDULE from './query.graphql';
-
-import * as styles from './style.css';
-import { ScheduleTable } from '../../components/schedule-table/index';
 
 export const monthIndexToName = [
   'Gennaio',
@@ -93,52 +89,6 @@ const parseSchedule = (
   schedule: Schedule_conference_schedule[],
 ): ParsedScheduleContainer => {
   const output: ParsedScheduleContainer = {};
-  let previousItem;
-  let currentGroup = 0;
-
-  for (const item of schedule) {
-    const start = new Date(item.start);
-    const end = new Date(item.end);
-    const day = start.getDate();
-
-    /* this does not really work for conferences that span multiple months!!!! */
-    /* also it's ugly */
-    if (!output.hasOwnProperty(day)) {
-      output[day] = {
-        year: start.getFullYear(),
-        month: start.getMonth(),
-        day,
-        schedule: {},
-      };
-      currentGroup = 0;
-    }
-
-    if (previousItem) {
-      const previousItemStart = new Date(previousItem.end);
-
-      if (previousItemStart.getTime() - end.getTime() > 60 * 60 * 1000) {
-        console.log('more than 20 minutes of distance');
-        currentGroup++;
-        if (!output[day].schedule.hasOwnProperty(currentGroup)) {
-          output[day].schedule[currentGroup] = { items: [] };
-        }
-        output[day].schedule[currentGroup].items.push(item);
-      } else {
-        console.log('less than 20 minutes of distance');
-
-        if (!output[day].schedule.hasOwnProperty(currentGroup)) {
-          output[day].schedule[currentGroup] = { items: [] };
-        }
-
-        output[day].schedule[currentGroup].items.push(item);
-      }
-    }
-    // output[day].schedule.push(item);
-
-    previousItem = item;
-
-    console.log(item.title, item.start);
-  }
-
+  /* removed test code */
   return output;
 };

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -1,15 +1,13 @@
 {
   "defaultSeverity": "error",
-  "extends": [
-    "tslint:latest",
-    "tslint-config-prettier"
-  ],
+  "extends": ["tslint:latest", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
     "ordered-imports": false,
     "interface-name": false,
     "object-literal-sort-keys": false,
-    "no-console": [true, "log"]
+    "no-console": [true, "log"],
+    "interface-over-type-literal": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
When I merged the `schedule` branch I also merged the test frontend I built which contained a lot of test code, I haven't removed most of it because it might be useful for whom will work on the frontend, but I fixed the code so that the linter does not fail anymore (basically removing some nonsense code 😅).

Also I disable the `interface-over-type-literal` rule as the use `type` to define a component `Props` or `State` (for example) instead of an interface