### PR TITLE
Add graphql-schema yarn command to package.json and document it in README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,9 +1,22 @@
 # PyCon Frontend
 
-## Install
+## 1. Install the dependencies
 
-`yarn install`
+Steps:
+* Install the dependencies running `yarn install`
 
-## Start the project
+## 2. Download the schema
 
-`yarn start`
+__WARNING__ - this is mandatory and must be executed in these cases:
+* Setting up the project for the first time
+* Every time the backend service's schema gets changed and it needs to be updated
+
+Steps:
+* Update the information about the endpoint for the schema inside the `apollo.config.js` file
+* Make sure the backend server is reachable (or start it if using a local environment)
+* Run the `yarn run graphql-schema` command to download the schema
+
+## 3. Start the project
+
+Steps:
+* Run the `yarn start` command

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "start": "concurrently \"yarn run dev\" \"yarn run dts --watch\" \"yarn run graphql-types --watch\"",
     "dev": "node scripts/start.js",
     "dts": "tcm src -c -o src_gen",
+    "graphql-schema": "apollo schema:download schema.json",
     "graphql-types": "apollo codegen:generate --target typescript --tagName graphql --schema schema.json --globalTypesFile=src/types/global.ts types"
   },
   "devDependencies": {


### PR DESCRIPTION
I've added a graphql-schema command to the package.json file for downloading the schema from the backend service configured inside the apollo.config.js file.
I've also updated the README.md file for the frontend extending the steps needed to start the project and including the graphql-schema command.