### PR TITLE
#35 Importer

### DIFF
--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -6,6 +6,7 @@ import pytz
 from django.core.management.base import BaseCommand
 from django.db import transaction, IntegrityError
 
+from conferences.models import AudienceLevel
 from languages.models import Language
 from pycon.settings.base import root
 
@@ -34,6 +35,14 @@ def create_languages():
     en, _ = Language.objects.get_or_create(code='en', defaults={'name': 'English'})
     it, _ = Language.objects.get_or_create(code='it', defaults={'name': 'Italiano'})
     return [en, it]
+
+
+def create_audience_levels():
+    beginner, _ = AudienceLevel.objects.get_or_create(name='Beginner')
+    intermediate, _ = AudienceLevel.objects.get_or_create(name='Intermediate')
+    advanced, _ = AudienceLevel.objects.get_or_create(name='Advanced')
+
+    return [beginner, intermediate, advanced]
 
 
 class Command(BaseCommand):
@@ -84,6 +93,7 @@ class Command(BaseCommand):
         self.stdout.write(f'Importing conferences...')
 
         languages = create_languages()
+        audience_levels = create_audience_levels()
 
         old_conf = list(self.c.execute('SELECT * FROM conference_conference'))
 
@@ -96,13 +106,13 @@ class Command(BaseCommand):
                         code=old_conf['code'],
                         timezone=OLD_DEAFAULT_TZ,
                         # topics=None,  # TODO
-                        # audience_levels=None,  # TODO
                         # submission_types=None,  # TODO
                         start=string_to_tzdatetime(old_conf['conference_start']),
                         end=string_to_tzdatetime(old_conf['conference_end'], day_end=True),
                     )
 
                     conf.languages.set(languages)
+                    conf.audience_levels.set(audience_levels)
 
                     for deadline in ['cfp', 'voting', 'refund']:
                         Deadline.objects.create(

--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -344,7 +344,7 @@ class Command(BaseCommand):
                         title=talk['title'],
                         language_id=languages.get(talk['language']),
                         defaults=dict(
-                            speaker=users_by_email.get(talk['speaker_email']),
+                            speaker_id=users_by_email.get(talk['speaker_email']),
                             abstract=talk['body'],
                             topic=topic,
                             type_id=types[talk['type']],
@@ -510,7 +510,7 @@ class Command(BaseCommand):
                 ticket2.assigned_to as ticket_user,
                 user.email as order_user,
                 fare.conference, fare.code as fare_code, fare.description as fare_description, fare.name as fare_name,
-                fare.price,
+                fare.price, fare.start_validity, fare.end_validity,
                 ord.method as payment_method, ord.payment_url, ord._complete as payment_complete,
                 ord.created as order_created,
                 orderitem.description as orderitem_description, orderitem.price as orderitem_price
@@ -539,6 +539,8 @@ class Command(BaseCommand):
                             name=orig_ticket['fare_name'],
                             description=orig_ticket['fare_description'],
                             price=Decimal(orig_ticket['price']),
+                            start=string_to_tzdatetime(orig_ticket['start_validity']),
+                            end=string_to_tzdatetime(orig_ticket['end_validity']),
                         )
                     )
 
@@ -575,7 +577,6 @@ class Command(BaseCommand):
                     )
                     if not created:
                         action = 'update'
-                    print(f'{action}d ticket {ticket.id}')
 
             except IntegrityError as exc:
                 action = 'skip'

--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -45,6 +45,7 @@ class Command(BaseCommand):
                 is_active=user['is_active'],
                 date_joined=user['date_joined'],
                 is_staff=user['is_staff'],
+                is_superuser=user['is_superuser'],
             ) for user in old_users if user['username'] not in new_usernames
         ])
 

--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -1,0 +1,68 @@
+import sqlite3
+
+from django.core.management.base import BaseCommand
+
+from pycon.settings.base import root
+
+
+DEFAULT_DB_PATH = root('p3.db')
+
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+
+class Command(BaseCommand):
+    help = 'Import old Pycon Site database'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--db',
+            dest='db_path',
+            action='store',
+            help='Absolute path of the SQLite db file',
+        )
+
+    def import_users(self):
+        from users.models import User
+
+        self.stdout.write(f'Importing users...')
+
+        old_users = list(self.c.execute('SELECT * FROM auth_user'))
+        old_usernames = {u['username'] for u in old_users}
+        new_usernames = {u.username for u in User.objects.all()}
+        skipping_users = new_usernames.intersection(old_usernames)
+        if skipping_users:
+            self.stdout.write(self.style.NOTICE(f'Skipping {len(skipping_users)} because they already exist'))
+        result = User.objects.bulk_create([
+            User(
+                username=user['username'],
+                email=user['email'],
+                password=user['password'],
+                is_active=user['is_active'],
+                date_joined=user['date_joined'],
+                is_staff=user['is_staff'],
+            ) for user in old_users if user['username'] not in new_usernames
+        ])
+
+        self.stdout.write(self.style.SUCCESS(f'{len(result)} users imported.'))
+
+    def handle(self, *args, **options):
+        self.stdout.write('Starting...')
+
+        db_path = options['db_path']
+        if not db_path:
+            self.stdout.write(self.style.NOTICE('DB path not specified, using default.'))
+            db_path = DEFAULT_DB_PATH
+        self.stdout.write(f'Using DB: {db_path}')
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = dict_factory
+        self.c = conn.cursor()
+
+        self.import_users()
+
+        self.stdout.write(self.style.SUCCESS('Done!'))

--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -446,6 +446,9 @@ class Command(BaseCommand):
                         user_id=ticket_user,
                         ticket_fare=ticket_fare,
                         order=order,
+                        defaults=dict(
+                            created=order.created,
+                        )
                     )
                     if not created:
                         action = 'update'

--- a/backend/importer/management/commands/import_old_db.py
+++ b/backend/importer/management/commands/import_old_db.py
@@ -530,7 +530,7 @@ class Command(BaseCommand):
                 with transaction.atomic():
 
                     order_user = users_by_email[orig_ticket['order_user']]
-                    ticket_user = users_by_email.get(orig_ticket['ticket_user'], order_user)
+                    ticket_user = users_by_email.get(orig_ticket['ticket_user'] or None, order_user)
 
                     ticket_fare, _ = TicketFare.objects.update_or_create(
                         conference_id=conferences[orig_ticket['conference']],

--- a/backend/payments/providers/__init__.py
+++ b/backend/payments/providers/__init__.py
@@ -5,8 +5,13 @@ from .stripe import Stripe
 
 PROVIDER_STRIPE = "stripe"
 PROVIDER_BANK = "bank"
+PROVIDER_PAYPAL = "paypal"
 
-PROVIDERS = Choices((PROVIDER_STRIPE, _("Stripe")), (PROVIDER_BANK, _("Bank Transfer")))
+PROVIDERS = Choices(
+    (PROVIDER_STRIPE, _("Stripe")),
+    (PROVIDER_BANK, _("Bank Transfer")),
+    (PROVIDER_PAYPAL, _("PayPal")),
+)
 
 PROVIDER_TO_IMPL = {PROVIDER_STRIPE: Stripe}
 

--- a/backend/pycon/settings/base.py
+++ b/backend/pycon/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "tickets.apps.TicketsConfig",
     "voting.apps.VotingConfig",
     "blog.apps.BlogConfig",
+    "importer",
 ]
 
 MIDDLEWARE = [
@@ -76,7 +77,9 @@ WSGI_APPLICATION = "pycon.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 
-DATABASES = {"default": env.db(default="sqlite:///{}".format(root("db.sqlite3")))}
+DATABASES = {
+    "default": env.db(default="sqlite:///{}".format(root("db.sqlite3")))
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators
@@ -88,7 +91,9 @@ PASSWORD_VALIDATORS = [
     "django.contrib.auth.password_validation.NumericPasswordValidator",
 ]
 
-AUTH_PASSWORD_VALIDATORS = [{"NAME": validator} for validator in PASSWORD_VALIDATORS]
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": validator} for validator in PASSWORD_VALIDATORS
+]
 
 
 # Internationalization
@@ -126,8 +131,12 @@ AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
 )
 
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = env("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY", default="")
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = env("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET", default="")
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = env(
+    "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY", default=""
+)
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = env(
+    "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET", default=""
+)
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 


### PR DESCRIPTION
Created the command `import_old_db` that takes the following parameters:
- `--db` to specify the full path of the source SQLite db file, default = `p3.db` (in the django root folder)
- `--entities` to specify which entities to import (see below)
- `--overwrite` some entities support this parameter to overwrite them while importing

The entities supported now are the following:
- `user`: imports User
- `submission_type`: SubmissionType
- `topic`: Topic
- `conference`: Conference and Deadline
- `room`: Room
- `submission`: 
- `schedule_item`: ScheduleItem
- `ticket`: TicketFare, Order, OrderItem, Ticket

Closes #35 