### PR TITLE
Remove `Type` from strawberry types

### DIFF
--- a/backend/blog/types.py
+++ b/backend/blog/types.py
@@ -2,13 +2,13 @@ from typing import Optional
 
 import strawberry
 from api.scalars import DateTime
-from users.types import UserType
+from users.types import User
 
 
 @strawberry.type
 class Post:
     id: strawberry.ID
-    author: UserType
+    author: User
     title: str
     slug: str
     excerpt: Optional[str]

--- a/backend/schedule/types.py
+++ b/backend/schedule/types.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 import strawberry
 from api.scalars import DateTime
 from submissions.types import Submission
-from users.types import UserType
+from users.types import User
 
 if TYPE_CHECKING:  # pragma: no cover
     from conferences.types import Conference
@@ -27,7 +27,7 @@ class ScheduleItem:
     type: str
 
     @strawberry.field
-    def additional_speakers(self, info) -> List[UserType]:
+    def additional_speakers(self, info) -> List[User]:
         return self.additional_speakers.all()
 
     @strawberry.field

--- a/backend/submissions/types.py
+++ b/backend/submissions/types.py
@@ -7,7 +7,7 @@ from voting.types import VoteType
 
 if TYPE_CHECKING:  # pragma: no cover
     from conferences.types import Conference, Topic, Duration, AudienceLevel
-    from users.types import UserType
+    from users.types import User
 
 
 @strawberry.type
@@ -24,7 +24,7 @@ class Submission:
     elevator_pitch: str
     notes: str
     abstract: str
-    speaker: "UserType"
+    speaker: "User"
     # helpers: str
     topic: "Topic"
     type: SubmissionType

--- a/backend/tests/users/test_login_users.py
+++ b/backend/tests/users/test_login_users.py
@@ -9,7 +9,7 @@ def _login_user(graphql_client, email, password):
         login(input: {email: $email, password: $password}) {
             __typename
 
-            ... on MeUserType {
+            ... on MeUser {
                 id
             }
 
@@ -31,7 +31,7 @@ def test_login_user(graphql_client, user_factory):
 
     response = _login_user(graphql_client, user.email, "ciao")
 
-    assert response["data"]["login"]["__typename"] == "MeUserType"
+    assert response["data"]["login"]["__typename"] == "MeUser"
     assert response["data"]["login"]["id"] == str(user.id)
 
     session = Session.objects.first()

--- a/backend/tests/users/test_register_user.py
+++ b/backend/tests/users/test_register_user.py
@@ -16,7 +16,7 @@ def _register_user(graphql_client, email, password):
                 nonFieldErrors
             }
 
-            ... on MeUserType {
+            ... on MeUser {
                 id
             }
         }
@@ -30,7 +30,7 @@ def _register_user(graphql_client, email, password):
 def test_register(graphql_client):
     response = _register_user(graphql_client, "test@user.it", "password")
 
-    assert response["data"]["register"]["__typename"] == "MeUserType"
+    assert response["data"]["register"]["__typename"] == "MeUser"
 
     user = User.objects.get(email="test@user.it")
 

--- a/backend/tickets/types.py
+++ b/backend/tickets/types.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import strawberry
 from conferences.types import TicketFare
-from users.types import UserType
+from users.types import User
 
 from . import QUESTION_TYPE_CHOICE, QUESTION_TYPE_TEXT
 
@@ -36,9 +36,9 @@ class UserAnswer:
 
 
 @strawberry.type
-class TicketType:
+class Ticket:
     id: strawberry.ID
-    user: UserType
+    user: User
     ticket_fare: TicketFare
 
     @strawberry.field

--- a/backend/users/mutations.py
+++ b/backend/users/mutations.py
@@ -1,27 +1,27 @@
 from strawberry_forms.mutations import FormMutation
 
 from .forms import LoginForm, RegisterForm
-from .types import MeUserType
+from .types import MeUser
 
 
 class Login(FormMutation):
     @classmethod
     def transform(cls, result):
-        return MeUserType(id=result.id, email=result.email)
+        return MeUser(id=result.id, email=result.email)
 
     class Meta:
         form_class = LoginForm
-        output_types = (MeUserType,)
+        output_types = (MeUser,)
 
 
 class Register(FormMutation):
     @classmethod
     def transform(cls, result):
-        return MeUserType(id=result.id, email=result.email)
+        return MeUser(id=result.id, email=result.email)
 
     class Meta:
         form_class = RegisterForm
-        output_types = (MeUserType,)
+        output_types = (MeUser,)
 
 
 class UsersMutations:

--- a/backend/users/schema.py
+++ b/backend/users/schema.py
@@ -1,13 +1,13 @@
 import strawberry
 from graphql import GraphQLError
 
-from .types import MeUserType
+from .types import MeUser
 
 
 @strawberry.type
 class UsersQuery:
     @strawberry.field
-    def me(self, info) -> MeUserType:
+    def me(self, info) -> MeUser:
         user = info.context["request"].user
 
         if not user.is_authenticated:

--- a/backend/users/types.py
+++ b/backend/users/types.py
@@ -4,17 +4,17 @@ import strawberry
 
 
 @strawberry.type
-class MeUserType:
+class MeUser:
     id: strawberry.ID
     email: str
 
     @strawberry.field
-    def tickets(self, info, conference: str) -> List["TicketType"]:
+    def tickets(self, info, conference: str) -> List["Ticket"]:
         return self.tickets.filter(ticket_fare__conference__code=conference).all()
 
 
 @strawberry.type
-class UserType:
+class User:
     id: strawberry.ID
     email: str
     name: str

--- a/backend/voting/types.py
+++ b/backend/voting/types.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 import strawberry
-from users.types import UserType
+from users.types import User
 
 if TYPE_CHECKING:  # pragma: no cover
     from submissions.types import Submission
@@ -28,5 +28,5 @@ class VoteValues(Enum):
 class VoteType:
     id: strawberry.ID
     value: VoteValues
-    user: UserType
+    user: User
     submission: "Submission"


### PR DESCRIPTION
We decided to not use the `Type` prefix, but for some types (user and ticket) it's still there