### PR TITLE
Implement language picker active state

### DIFF
--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -19,16 +19,19 @@ import { Logo } from "../logo";
 import { SocialLinks } from "../social-links";
 import { SnakeBurger } from "./snake-burger";
 
-const LanguagePicker: React.SFC = props => {
+const LanguagePicker: React.SFC<{ language: string }> = ({
+  language,
+  ...props
+}) => {
   const alternateLinks = useAlternateLinks();
 
   return (
     <Flex sx={{ alignItems: "center", height: 50, mt: "-3px" }} {...props}>
       <Link href={alternateLinks.en} sx={{ height: 40 }}>
-        <EnglishIcon sx={{ width: 40, mr: 2 }} />
+        <EnglishIcon active={language === "en"} sx={{ width: 40, mr: 2 }} />
       </Link>
       <Link href={alternateLinks.it} sx={{ height: 40 }}>
-        <ItalianIcon sx={{ width: 40, mr: 4 }} />
+        <ItalianIcon active={language === "it"} sx={{ width: 40, mr: 4 }} />
       </Link>
     </Flex>
   );
@@ -132,6 +135,7 @@ export const HeaderContent = ({ location }: { location: any }) => {
           }}
         >
           <LanguagePicker
+            language={language}
             sx={{
               display: ["none", "block"],
             }}
@@ -186,6 +190,7 @@ export const HeaderContent = ({ location }: { location: any }) => {
             }}
           >
             <LanguagePicker
+              language={language}
               sx={{
                 display: ["block", "none"],
               }}

--- a/frontend/src/components/icons/english.tsx
+++ b/frontend/src/components/icons/english.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-export const EnglishIcon: React.SFC = props => (
+export const EnglishIcon: React.SFC<{ active: boolean }> = ({
+  active,
+  ...props
+}) => (
   <svg viewBox="0 0 50 50" fill="none" {...props}>
     <path
       d="M50 25c0 13.806-11.194 25-25 25C11.193 50 0 38.807 0 25S11.193 0 25 0s25 11.193 25 25z"
@@ -19,6 +22,6 @@ export const EnglishIcon: React.SFC = props => (
       fill="#D80027"
     />
     <circle cx={25} cy={25} r={23} stroke="#000" strokeWidth={4} />
-    <circle cx={25} cy={25} r={19} stroke="#fff" strokeWidth={4} />
+    {active && <circle cx={25} cy={25} r={19} stroke="#fff" strokeWidth={4} />}
   </svg>
 );

--- a/frontend/src/components/icons/italian.tsx
+++ b/frontend/src/components/icons/italian.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-export const ItalianIcon: React.SFC = props => (
+export const ItalianIcon: React.SFC<{ active: boolean }> = ({
+  active,
+  ...props
+}) => (
   <svg viewBox="0 0 50 50" fill="none" {...props}>
     <g clipPath="url(#prefix__clip0)">
       <path
@@ -16,6 +19,9 @@ export const ItalianIcon: React.SFC = props => (
         fill="#6DA544"
       />
       <circle cx={25} cy={25} r={23} stroke="#000" strokeWidth={4} />
+      {active && (
+        <circle cx={25} cy={25} r={19} stroke="#fff" strokeWidth={4} />
+      )}
     </g>
     <defs>
       <clipPath id="prefix__clip0">


### PR DESCRIPTION
The white circle around the flag should be visible only to the active language

<img width="146" alt="image" src="https://user-images.githubusercontent.com/3382153/69796084-a86e7300-11cd-11ea-8e76-e8fee9e0ccfd.png">

<img width="132" alt="image" src="https://user-images.githubusercontent.com/3382153/69796088-ab696380-11cd-11ea-9c7c-ca0098f61c40.png">


Dave's feedback:

> Just spotted the white circle is still on UK when it should be on IT
