### PR TITLE
Use host volume to save pretix's /data/media

### DIFF
--- a/infrastructure/eb/pretix/Dockerrun.aws.json
+++ b/infrastructure/eb/pretix/Dockerrun.aws.json
@@ -8,5 +8,11 @@
     {
       "ContainerPort": "80"
     }
+  ],
+  "Volumes": [
+    {
+      "HostDirectory": "/var/pretix/data/media",
+      "ContainerDirectory": "/data/media"
+    }
   ]
 }


### PR DESCRIPTION
Configure EB to create a volume in the host (the EC2 instance) and bind the Pretix container to use it.

While Pretix's documentation suggests binding the entire `/data` directory, we only bind `/data/media/` to keep the event's generated CSS/user's uploaded files when deploying.

In the future, we might be able to use Cloudwatch to keep the logs (`/data/logs`) and also use S3 to store the CSS/media.

