### PR TITLE
Fix language picker not working on dynamic pages

### DIFF
--- a/frontend/src/helpers/wrap-page-element.tsx
+++ b/frontend/src/helpers/wrap-page-element.tsx
@@ -73,6 +73,29 @@ const isSocial = (props: Props["props"]) => {
   );
 };
 
+const getAlternateLinks = (props: Props["props"]) => {
+  if (typeof window !== "undefined") {
+    /*
+      when we are not SSO,
+      use the location's pathname to generate
+      more specific URLs:
+
+      Example /en/submission/{ID} cannot be generated server side,
+      so we replace it with the current pathname.
+    */
+    const pathname = window.location.pathname
+      .replace("/en/", "")
+      .replace("/it/", "");
+
+    return {
+      en: `/en/${pathname}`,
+      it: `/it/${pathname}`,
+    };
+  }
+
+  return props.pageContext.alternateLinks;
+};
+
 export const wrapPageElement = ({ element, props }: Props) => (
   <Fragment>
     <Global styles={reset} />
@@ -86,9 +109,7 @@ export const wrapPageElement = ({ element, props }: Props) => (
         element
       ) : (
         <ConferenceContext.Provider value={props.pageContext.conferenceCode}>
-          <AlternateLinksContext.Provider
-            value={props.pageContext.alternateLinks}
-          >
+          <AlternateLinksContext.Provider value={getAlternateLinks(props)}>
             <LanguageContext.Provider value={props.pageContext.language}>
               <IntlProvider
                 locale={props.pageContext.language}


### PR DESCRIPTION
Right now when you are on http://localhost:4000/it/submission/20 and try to switch to English (for example), you get redirected to `http://localhost:4000/it/submission` instead of `http://localhost:4000/en/submission/20` because the language picker uses the URL generated by gatsby at build time, which doesn't/can't know about the submission you are in.

This PR keeps the current behavior at build time, but when running in the client it uses the current browser URL to generate better language URLs.

