### PR TITLE
Add apollo resetStore when Logout succeed

### DIFF
--- a/frontend/src/app/profile/logout.tsx
+++ b/frontend/src/app/profile/logout.tsx
@@ -4,11 +4,11 @@ import { Box, Button, Heading, Text } from "@theme-ui/components";
 import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
+import { client } from "../../apollo/client";
 import { Alert } from "../../components/alert";
 import { LogoutMutation } from "../../generated/graphql-backend";
 import { useLoginState } from "./hooks";
 import LOGOUT_MUTATION from "./logout.graphql";
-import { client } from "../../apollo/client";
 
 export const Logout: React.SFC<{ lang: string }> = ({ lang }) => {
   const [logout, { error, loading, data }] = useMutation<LogoutMutation>(

--- a/frontend/src/app/profile/logout.tsx
+++ b/frontend/src/app/profile/logout.tsx
@@ -8,6 +8,7 @@ import { Alert } from "../../components/alert";
 import { LogoutMutation } from "../../generated/graphql-backend";
 import { useLoginState } from "./hooks";
 import LOGOUT_MUTATION from "./logout.graphql";
+import { client } from "../../apollo/client";
 
 export const Logout: React.SFC<{ lang: string }> = ({ lang }) => {
   const [logout, { error, loading, data }] = useMutation<LogoutMutation>(
@@ -25,6 +26,7 @@ export const Logout: React.SFC<{ lang: string }> = ({ lang }) => {
 
   if (data && data.logout.__typename === "OperationResult" && data.logout.ok) {
     setLoggedIn(false);
+    client.resetStore();
     return <Redirect noThrow={true} to={`/${lang}/`} />;
   }
 


### PR DESCRIPTION
When you are switching between accounts the cache was not cleaned

> Since Apollo caches all of your query results, it's important to get
rid of them when the login state changes
https://www.apollographql.com/docs/react/networking/authentication/#reset-store-on-logout