### PR TITLE
Show order status in the hotel admin row

### DIFF
--- a/backend/hotels/admin.py
+++ b/backend/hotels/admin.py
@@ -17,13 +17,13 @@ class HotelRoomReservationAdmin(admin.ModelAdmin):
     list_display = ("order_code", "order_status", "room", "user", "checkin", "checkout")
     list_filter = ("order_code", "room__conference", "room")
 
-    def order_status(self, obj):
+    def order_status(self, obj):  # pragma: no cover
         if obj.order_code not in self._reservation_status:
             return _("Unknown")
 
         return order_status_to_text(self._reservation_status[obj.order_code])
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         queryset = super().get_queryset(request)
 
         codes = [reservation.order_code for reservation in queryset]

--- a/backend/hotels/admin.py
+++ b/backend/hotels/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.utils.translation import ugettext_lazy as _
+from pretix.db import get_orders_status
+from pretix.utils import order_status_to_text
 
 from .models import HotelRoom, HotelRoomReservation
 
@@ -11,5 +14,18 @@ class HotelRoomAdmin(admin.ModelAdmin):
 
 @admin.register(HotelRoomReservation)
 class HotelRoomReservationAdmin(admin.ModelAdmin):
-    list_display = ("order_code", "room", "user", "checkin", "checkout")
+    list_display = ("order_code", "order_status", "room", "user", "checkin", "checkout")
     list_filter = ("order_code", "room__conference", "room")
+
+    def order_status(self, obj):
+        if obj.order_code not in self._reservation_status:
+            return _("Unknown")
+
+        return order_status_to_text(self._reservation_status[obj.order_code])
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+
+        codes = [reservation.order_code for reservation in queryset]
+        self._reservation_status = get_orders_status(codes)
+        return queryset

--- a/backend/hotels/tests/test_admin.py
+++ b/backend/hotels/tests/test_admin.py
@@ -1,0 +1,14 @@
+# from hotels.admin import HotelRoomReservationAdmin
+# from hotels.models import HotelRoomReservation
+from pytest import mark
+
+
+@mark.django_db
+@mark.parametrize(
+    "code", [("n", "Pending"), ("p", "Paid"), ("e", "Expired"), ("c", "Canceled")]
+)
+def test_admin_order_status(code, mocker):
+    # obj = HotelRoomReservation(pretix_order_code="A")
+    # admin = HotelRoomReservationAdmin(HotelRoomReservation)
+    # admin.order_status()
+    pass

--- a/backend/pretix/db.py
+++ b/backend/pretix/db.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from django.conf import settings
 from django.db import connections
 
@@ -30,3 +32,18 @@ def user_has_admission_ticket(email: str, event_slug: int):
         exists = cursor.fetchone()
 
     return exists[0]
+
+
+def get_orders_status(orders: List[str]):
+    if settings.SIMULATE_PRETIX_DB:
+        return {}
+
+    with connections["pretix"].cursor() as cursor:
+        cursor.execute(
+            """SELECT code, status FROM pretixbase_order WHERE code = ANY(%s)""",
+            [orders],
+        )
+
+        statuses = cursor.fetchall()
+
+    return {status[0]: status[1] for status in statuses}

--- a/backend/pretix/tests/test_get_orders_status.py
+++ b/backend/pretix/tests/test_get_orders_status.py
@@ -1,0 +1,21 @@
+from django.test import override_settings
+from pretix.db import get_orders_status
+
+
+@override_settings(SIMULATE_PRETIX_DB=True)
+def test_no_order_status_when_the_db_is_simulated():
+    assert get_orders_status(["A"]) == {}
+
+
+@override_settings(SIMULATE_PRETIX_DB=False)
+def test_get_order_statuses(mocker):
+    connections_mock = mocker.patch("pretix.db.connections")
+    connections_mock.__getitem__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = (  # noqa
+        ("A", "p"),
+        ("B", "c"),
+        ("C", "n"),
+    )
+
+    statuses = get_orders_status(["A", "B", "C"])
+
+    assert statuses == {"A": "p", "B": "c", "C": "n"}

--- a/backend/pretix/tests/test_utils.py
+++ b/backend/pretix/tests/test_utils.py
@@ -1,0 +1,9 @@
+from pretix.utils import order_status_to_text
+from pytest import mark
+
+
+@mark.parametrize(
+    "code", [("n", "Pending"), ("p", "Paid"), ("e", "Expired"), ("c", "Canceled")]
+)
+def convert_code_to_text(code):
+    assert order_status_to_text(code[0]) == code[1]

--- a/backend/pretix/utils.py
+++ b/backend/pretix/utils.py
@@ -1,0 +1,5 @@
+ORDER_STATUS_TO_TEXT = {"n": "Pending", "p": "Paid", "e": "Expired", "c": "Canceled"}
+
+
+def order_status_to_text(status):
+    return ORDER_STATUS_TO_TEXT[status]


### PR DESCRIPTION
TODO:

- [ ] Find a better way to store the status of the orders

Right now `get_queryset` is called twice

```python
    def get_queryset(self, request):
        queryset = super().get_queryset(request)

        codes = [reservation.order_code for reservation in queryset]
        self._reservation_status = get_orders_status(codes)
        return queryset
```

The reason I am using get_queryset instead of fetching the order in the admin field admin is that I want to get all the statuses with 1 query to the database, instead of N

<img width="948" alt="image" src="https://user-images.githubusercontent.com/3382153/73146272-c3fcd980-40a9-11ea-98da-476c5a4c3e4c.png">
