### PR TITLE
Fix pretix error 400 when a not required answer receives an empty value

### DIFF
--- a/backend/pretix/__init__.py
+++ b/backend/pretix/__init__.py
@@ -130,6 +130,9 @@ def normalize_answers(ticket: CreateOrderTicket, questions: dict):
     for answer in ticket.answers or []:
         question = questions[answer.question_id]
 
+        if not answer.value and not question["required"]:
+            continue
+
         answer_data = {
             "question": answer.question_id,
             "answer": answer.value,


### PR DESCRIPTION
If you edit and then clear a not required question you get
a validation error saying answer cannot be blank