### PR TITLE
Add page field to link types

### DIFF
--- a/backend/api/cms/types.py
+++ b/backend/api/cms/types.py
@@ -1,6 +1,7 @@
 import typing
 
 import strawberry
+from api.pages.types import Page
 
 from ..helpers.i18n import make_localized_resolver
 
@@ -17,6 +18,7 @@ class MenuLink:
     title: str = strawberry.field(resolver=make_localized_resolver("title"))
     target: typing.Optional[str]
     is_primary: bool
+    page: typing.Optional[Page]
 
 
 @strawberry.type


### PR DESCRIPTION
When moving to next we will use the slugs of the pages in the links to allow client side routing.