### PR TITLE
Use ubuntu-20 for our github actions

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -3,19 +3,18 @@ name: Backend checks
 on:
   pull_request:
     paths:
-    - 'backend/**/*'
-    - 'backend/*'
-    - '.github/workflows/backend-checks.yml'
-
+      - "backend/**/*"
+      - "backend/*"
+      - ".github/workflows/backend-checks.yml"
 
 jobs:
   check-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7.9'
+          python-version: "3.7.9"
       - run: pip install poetry
 
       - name: Cache Poetry

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -3,13 +3,13 @@ name: Backend tests
 on:
   pull_request:
     paths:
-    - 'backend/**/*'
-    - 'backend/*'
-    - '.github/workflows/backend-test.yml'
+      - "backend/**/*"
+      - "backend/*"
+      - ".github/workflows/backend-test.yml"
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:
@@ -19,7 +19,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-        - 5432/tcp
+          - 5432/tcp
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7.9'
+          python-version: "3.7.9"
       - run: pip install poetry
 
       - name: Cache Poetry
@@ -55,26 +55,26 @@ jobs:
       - name: pytest
         working-directory: backend
         run: |
-            set +e
-            OUTPUT=$(poetry run pytest --cov-report xml --cov=. --cov-fail-under 99)
-            STATUS=$?
-            echo "$OUTPUT"
-            cd ..
-            codecov
-            exit $STATUS
+          set +e
+          OUTPUT=$(poetry run pytest --cov-report xml --cov=. --cov-fail-under 99)
+          STATUS=$?
+          echo "$OUTPUT"
+          cd ..
+          codecov
+          exit $STATUS
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports['5432'] }}/postgres
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7.9'
+          python-version: "3.7.9"
       - run: pip install poetry
       - name: Install dependencies
         working-directory: backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-and-push-backend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master
@@ -24,7 +24,7 @@ jobs:
         run: docker push pythonitalia/pycon-backend:latest
 
   build-lambda-backend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master
@@ -41,7 +41,7 @@ jobs:
         run: docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/production-pycon-backend:latest
 
   terraform:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build-lambda-backend]
     defaults:
       run:
@@ -82,7 +82,7 @@ jobs:
           TF_VAR_pinpoint_application_id: ${{ secrets.TF_VAR_pinpoint_application_id }}
 
   deploy-to-eb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [terraform, build-and-push-backend]
 
     steps:
@@ -99,7 +99,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   migrate-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [terraform]
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   eslint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -1,64 +1,64 @@
 on:
   pull_request:
     paths:
-    - 'infrastructure/**/*'
-    - 'infrastructure/*'
+      - "infrastructure/**/*"
+      - "infrastructure/*"
 
 name: Terraform Lint
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - name: terraform-fmt
-      uses: hashicorp/terraform-github-actions/fmt@v0.3.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_ACTION_WORKING_DIR: ./infrastructure
+      - name: terraform-fmt
+        uses: hashicorp/terraform-github-actions/fmt@v0.3.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TF_ACTION_WORKING_DIR: ./infrastructure
 
   plan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - name: terraform-init
-      uses: hashicorp/terraform-github-actions/init@v0.3.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_ACTION_WORKING_DIR: ./infrastructure
+      - name: terraform-init
+        uses: hashicorp/terraform-github-actions/init@v0.3.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_ACTION_WORKING_DIR: ./infrastructure
 
-    - name: terraform-validate
-      uses: hashicorp/terraform-github-actions/validate@v0.3.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_ACTION_WORKING_DIR: ./infrastructure
+      - name: terraform-validate
+        uses: hashicorp/terraform-github-actions/validate@v0.3.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_ACTION_WORKING_DIR: ./infrastructure
 
-    - name: terraform-plan
-      uses: ./.github/terraform-plan-action
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_VAR_database_password: ${{ secrets.TF_VAR_database_password }}
-        TF_VAR_secret_key: ${{ secrets.TF_VAR_secret_key }}
-        TF_VAR_mapbox_public_api_key: ${{ secrets.TF_VAR_mapbox_public_api_key }}
-        TF_VAR_sentry_dsn: ${{ secrets.TF_VAR_sentry_dsn }}
-        TF_VAR_ssl_certificate: ${{ secrets.TF_VAR_ssl_certificate }}
-        TF_VAR_slack_incoming_webhook_url: ${{ secrets.TF_VAR_slack_incoming_webhook_url }}
-        TF_VAR_social_auth_google_oauth2_key: ${{ secrets.TF_VAR_social_auth_google_oauth2_key }}
-        TF_VAR_social_auth_google_oauth2_secret: ${{ secrets.TF_VAR_social_auth_google_oauth2_secret }}
-        TF_VAR_mail_user: ${{ secrets.TF_VAR_mail_user }}
-        TF_VAR_mail_password: ${{ secrets.TF_VAR_mail_password }}
-        TF_VAR_pretix_secret_key: ${{ secrets.TF_VAR_pretix_secret_key }}
-        TF_VAR_pretix_api_token:  ${{ secrets.TF_VAR_pretix_api_token }}
-        TF_VAR_pinpoint_application_id: ${{ secrets.TF_VAR_pinpoint_application_id }}
-        TF_ACTION_WORKING_DIR: ./infrastructure
-        TF_ACTION_WORKSPACE: production
+      - name: terraform-plan
+        uses: ./.github/terraform-plan-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_database_password: ${{ secrets.TF_VAR_database_password }}
+          TF_VAR_secret_key: ${{ secrets.TF_VAR_secret_key }}
+          TF_VAR_mapbox_public_api_key: ${{ secrets.TF_VAR_mapbox_public_api_key }}
+          TF_VAR_sentry_dsn: ${{ secrets.TF_VAR_sentry_dsn }}
+          TF_VAR_ssl_certificate: ${{ secrets.TF_VAR_ssl_certificate }}
+          TF_VAR_slack_incoming_webhook_url: ${{ secrets.TF_VAR_slack_incoming_webhook_url }}
+          TF_VAR_social_auth_google_oauth2_key: ${{ secrets.TF_VAR_social_auth_google_oauth2_key }}
+          TF_VAR_social_auth_google_oauth2_secret: ${{ secrets.TF_VAR_social_auth_google_oauth2_secret }}
+          TF_VAR_mail_user: ${{ secrets.TF_VAR_mail_user }}
+          TF_VAR_mail_password: ${{ secrets.TF_VAR_mail_password }}
+          TF_VAR_pretix_secret_key: ${{ secrets.TF_VAR_pretix_secret_key }}
+          TF_VAR_pretix_api_token: ${{ secrets.TF_VAR_pretix_api_token }}
+          TF_VAR_pinpoint_application_id: ${{ secrets.TF_VAR_pinpoint_application_id }}
+          TF_ACTION_WORKING_DIR: ./infrastructure
+          TF_ACTION_WORKSPACE: production


### PR DESCRIPTION
Update to use `ubuntu-20.04` for our Github actions

We can switch back to `ubuntu-latest` once the tag is updated,
updating the version should allow us to:

1. Make sure our pipeline still works under 20.04, so we are ready when the switch happens later this month/next
2. Have AWS CLI v2 fixing our issue with the "Migrate DB" workflow

