### PR TITLE
Allow only one deployment at the time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy
 
+concurrency: deploy-${{ fromJSON('["pastaporto", "production"]')[github.ref == 'refs/heads/main'] }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Why

Running 2 deploy at the workflow might cause undefined behaviours where some services are deployed at commit X and others at commit Y

This is part 1 of a refactor of our github deployment pipeline

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Run /deploy here, 
Watch the workflow start
Run /deploy again
it should fail for the other workflow to finish

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/3382153/142709650-be11968c-8139-43d8-826c-d963fbb83ed3.png">

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/3382153/142709653-92390263-412c-4564-a25f-c5ad561b0187.png">


<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
