### PR TITLE
Fix Django warnings about missing default auto field

### DIFF
--- a/backend/pycon/settings/base.py
+++ b/backend/pycon/settings/base.py
@@ -215,3 +215,5 @@ SQS_QUEUE_URL = env("SQS_QUEUE_URL", default="")
 MAILCHIMP_SECRET_KEY = env("MAILCHIMP_SECRET_KEY", default="")
 MAILCHIMP_DC = env("MAILCHIMP_DC", default="us3")
 MAILCHIMP_LIST_ID = env("MAILCHIMP_LIST_ID", default="")
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
## Why

Fixes almost all warnings of pycon-backend
Only two left:

```text
pycon-backend_1           |
pycon-backend_1           | WARNINGS:
pycon-backend_1           | social_django.Partial.data: (fields.W904) django.contrib.postgres.fields.JSONField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
pycon-backend_1           | 	HINT: Use django.db.models.JSONField instead.
pycon-backend_1           | social_django.UserSocialAuth.extra_data: (fields.W904) django.contrib.postgres.fields.JSONField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
pycon-backend_1           | 	HINT: Use django.db.models.JSONField instead.
```

that we can fix by removing social_django in the future

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Clone the PR, all those warnings about auto field should disappear

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
