### PR TITLE
Hide unavailable tickets by default

### DIFF
--- a/backend/api/conferences/types.py
+++ b/backend/api/conferences/types.py
@@ -101,8 +101,12 @@ class Conference:
         return str(self.timezone)
 
     @strawberry.field
-    def tickets(self, info, language: str) -> List[TicketItem]:
-        return get_conference_tickets(self, language=language)
+    def tickets(
+        self, info, language: str, show_unavailable_tickets: bool = False
+    ) -> List[TicketItem]:
+        return get_conference_tickets(
+            self, language=language, show_unavailable_tickets=show_unavailable_tickets
+        )
 
     @strawberry.field
     def hotel_rooms(self, info) -> List[HotelRoom]:

--- a/backend/api/pretix/query.py
+++ b/backend/api/pretix/query.py
@@ -1,6 +1,9 @@
 import math
+from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
+
+from dateutil.parser import parse
 
 import pretix
 import pretix.db
@@ -104,8 +107,30 @@ def get_questions_for_ticket(item, questions, language):
     ]
 
 
-def get_conference_tickets(conference: Conference, language: str) -> List[TicketItem]:
+def _is_ticket_available(item) -> bool:
+    if available_from := item["available_from"]:
+        available_from = parse(available_from)
+
+        if available_from > datetime.now():
+            return False
+
+    if available_until := item["available_until"]:
+        available_until = parse(available_until)
+
+        if available_until < datetime.now():
+            return False
+
+    return True
+
+
+def get_conference_tickets(
+    conference: Conference, language: str, show_unavailable_tickets: bool = False
+) -> List[TicketItem]:
     items = pretix.get_items(conference)
+
+    if not show_unavailable_tickets:
+        items = {key: item for key, item in items.items() if _is_ticket_available(item)}
+
     questions = pretix.get_questions(conference).values()
     categories = pretix.get_categories(conference)
     quotas = pretix.get_quotas(conference)


### PR DESCRIPTION
This PR hides unavailable tickets by default, I've done this with a parameter as we might want to change how it works on the client in future (ie, showing tickets, but keeping them as disabled).

Pretix doesn't have a filter for availability times, so I filter them by hand

we also always show tickets if both available_from and available_until are None