### PR TITLE
Fix safari login using first-party domain

### DIFF
--- a/association-frontend/next.config.js
+++ b/association-frontend/next.config.js
@@ -1,9 +1,18 @@
-const { API_URL, API_URL_SERVER, STRIPE_KEY } = process.env;
+const { API_URL, API_URL_SERVER, STRIPE_KEY, GRAPHQL_GATEWAY_URL } =
+  process.env;
 
 module.exports = {
   env: {
     API_URL: API_URL,
     API_URL_SERVER: API_URL_SERVER,
     STRIPE_KEY: STRIPE_KEY,
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/graphql",
+        destination: GRAPHQL_GATEWAY_URL,
+      },
+    ];
   },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ x-defaults:
     PRETIX_API_TOKEN: None # ask for a token
     SECRET_KEY: secret-key
     SLACK_INCOMING_WEBHOOK_URL: None
-    API_URL: http://127.0.0.1:4000/graphql
+    API_URL: /graphql
+    GRAPHQL_GATEWAY_URL: http://gateway:4000/graphql
     API_URL_SERVER: http://gateway:4000/graphql
     # Stripe
     STRIPE_SUBSCRIPTION_PRICE_ID: price_1IkVzxD5MZ3GejSORRBZCvK6

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,7 @@ const {
   API_TOKEN,
   NEXT_PUBLIC_SOCIAL_CARD_SERVICE,
   NEXT_PUBLIC_VERCEL_URL,
+  GRAPHQL_GATEWAY_URL,
 } = process.env;
 
 module.exports = withSourceMaps({
@@ -29,7 +30,15 @@ module.exports = withSourceMaps({
       {
         source: "/admin/:match*",
         destination: "https://admin.pycon.it/admin/:match",
-        permanent: true,
+        permanent: false,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/graphql",
+        destination: GRAPHQL_GATEWAY_URL,
       },
     ];
   },

--- a/frontend/src/pages/_middleware.ts
+++ b/frontend/src/pages/_middleware.ts
@@ -10,6 +10,7 @@ export function middleware(req: NextRequest, _ev: NextFetchEvent) {
     !PUBLIC_FILE.test(req.nextUrl.pathname) &&
     !req.nextUrl.pathname.includes("/api/") &&
     !req.nextUrl.pathname.includes("/admin") &&
+    !req.nextUrl.pathname.includes("/graphql") &&
     req.nextUrl.locale === "default";
   const locale = getLocale(req.cookies.pyconLocale);
 


### PR DESCRIPTION
## Why

Login doesn't work on Safari right now and might stop working on Chrome in the future since we use third-party cookies on pycon.it to share the login between associazione.python.it and pycon.it. 

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Staging URLs queries should work fine

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
