### PR TITLE
Use Lax cookies now that graphql is first-party

### DIFF
--- a/gateway/actions/auth-action.ts
+++ b/gateway/actions/auth-action.ts
@@ -44,7 +44,7 @@ export class AuthAction extends PastaportoAction<
         httpOnly: true,
         maxAge: SECONDS_IN_84_DAYS,
         path: "/",
-        sameSite: "none",
+        sameSite: "lax",
         secure: !IS_DEV,
       },
     });
@@ -59,7 +59,7 @@ export class AuthAction extends PastaportoAction<
           httpOnly: true,
           maxAge: SECONDS_IN_84_DAYS,
           path: "/",
-          sameSite: "none",
+          sameSite: "lax",
           secure: !IS_DEV,
         },
       });


### PR DESCRIPTION
## Why

Now that GraphQL requests are on /graphql first-party, we do not need SameSite=none anymore since all requests are now first-party.
This also means that this fixes the local login without having to use HTTPs locally

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Deploying to staging.
Try a staging URL, login should work

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
