### PR TITLE
Fix language switch on tickets, more cache reuse

### DIFF
--- a/backend/api/pretix/query.py
+++ b/backend/api/pretix/query.py
@@ -65,7 +65,7 @@ def _create_ticket_type_from_api(item, id, categories, questions, quotas, langua
     category = _get_category_for_ticket(item, categories)
 
     return TicketItem(
-        id=id,
+        id=f"{id}-{language}",
         name=_get_by_language(item, "name", language),
         description=_get_by_language(item, "description", language),
         category=_get_by_language(category, "name", language),

--- a/frontend/src/components/tickets-page/wrapper.tsx
+++ b/frontend/src/components/tickets-page/wrapper.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/router";
 import { Alert } from "~/components/alert";
 import { MetaTags } from "~/components/meta-tags";
 import { useLoginState } from "~/components/profile/hooks";
+import { useCurrentUser } from "~/helpers/use-current-user";
 import { useCurrentLanguage } from "~/locale/context";
 import { TicketsQueryResult, useTicketsQuery } from "~/types";
 
@@ -33,19 +34,20 @@ export const TicketsPageWrapper: React.SFC<Props> = ({ children }) => {
   const code = process.env.conferenceCode;
   const language = useCurrentLanguage();
   const [isLoggedIn] = useLoginState();
+  const { user: me } = useCurrentUser({
+    skip: !isLoggedIn,
+  });
 
   const { loading, error, data } = useTicketsQuery({
     variables: {
       conference: code,
       language,
-      isLogged: isLoggedIn,
     },
   });
 
   const hotelRooms = data?.conference.hotelRooms || [];
   const tickets = data?.conference.tickets || [];
   const conference = data?.conference;
-  const me = data?.me;
   const router = useRouter();
 
   const { state } = useCart();

--- a/frontend/src/pages/tickets/index.tsx
+++ b/frontend/src/pages/tickets/index.tsx
@@ -67,8 +67,11 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     prefetchSharedQueries(client, locale),
     queryTickets(client, {
       conference: process.env.conferenceCode,
-      language: locale,
-      isLogged: false,
+      language: "it",
+    }),
+    queryTickets(client, {
+      conference: process.env.conferenceCode,
+      language: "en",
     }),
   ]);
 

--- a/frontend/src/pages/tickets/tickets.graphql
+++ b/frontend/src/pages/tickets/tickets.graphql
@@ -1,9 +1,4 @@
-query Tickets($conference: String!, $language: String!, $isLogged: Boolean!) {
-  me @include(if: $isLogged) {
-    id
-    email
-  }
-
+query Tickets($conference: String!, $language: String!) {
   conference(code: $conference) {
     id
     start


### PR DESCRIPTION
## Why

Changing language on the tickets page doesn't update the tickets description
We also have a double fetching of tickets because of the "isLogged" variable that re-fetches the tickets because the user is now logged in

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Go to the tickets page, change language and it should work fine

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
