### PR TITLE
Disable suggestions and branding on the video on homepage

### DIFF
--- a/frontend/src/components/youtube-lite/index.tsx
+++ b/frontend/src/components/youtube-lite/index.tsx
@@ -23,7 +23,7 @@ export const YouTubeLite: React.SFC<{ videoId: string }> = ({
         frameBorder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen={true}
-        src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1`}
+        src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&modestbranding=1&rel=0`}
         {...props}
       />
     );


### PR DESCRIPTION
Added 2 option sin the Youtube `src` attribute:

... set the modestbranding parameter value to 1 to prevent the YouTube logo from displaying in the control bar.
https://developers.google.com/youtube/player_parameters#modestbranding

... if the rel parameter is set to 0, related videos will come from the same channel as the video that was just played
https://developers.google.com/youtube/player_parameters#rel

## Why

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
