### PR TITLE
Add submission author in the slack notification

### DIFF
--- a/backend/api/submissions/forms.py
+++ b/backend/api/submissions/forms.py
@@ -126,7 +126,7 @@ class SendSubmissionForm(SubmissionForm):
             admin_url=request.build_absolute_uri(instance.get_admin_url()),
             duration=instance.duration.duration,
             topic=instance.topic.name,
-            author_id=instance.author_id,
+            speaker_id=instance.speaker_id,
         )
         return instance
 

--- a/backend/api/submissions/forms.py
+++ b/backend/api/submissions/forms.py
@@ -126,6 +126,7 @@ class SendSubmissionForm(SubmissionForm):
             admin_url=request.build_absolute_uri(instance.get_admin_url()),
             duration=instance.duration.duration,
             topic=instance.topic.name,
+            author_id=instance.author_id,
         )
         return instance
 

--- a/backend/domain_events/handler.py
+++ b/backend/domain_events/handler.py
@@ -5,7 +5,7 @@ from pythonit_toolkit.service_client import ServiceClient
 from integrations import slack
 
 USER_NAME_FROM_ID = """query UserNameFromId($userId: ID!) {
-    user(id: $id) {
+    user(id: $userId) {
         fullname
         name
         username
@@ -20,7 +20,7 @@ def handle_new_cfp_submission(data):
     admin_url = data["admin_url"]
     topic = data["topic"]
     duration = data["duration"]
-    author_id = data["author_id"]
+    speaker_id = data["speaker_id"]
 
     client = ServiceClient(
         url=f"{settings.USERS_SERVICE}/internal-api",
@@ -29,12 +29,12 @@ def handle_new_cfp_submission(data):
         jwt_secret=settings.SERVICE_TO_SERVICE_SECRET,
     )
     client_execute = async_to_sync(client.execute)
-    user_result = client_execute(USER_NAME_FROM_ID, {"userId": author_id})
+    user_result = client_execute(USER_NAME_FROM_ID, {"userId": speaker_id})
     user_data = user_result.data
     user_name = (
-        user_data["fullname"]
-        or user_data["name"]
-        or user_data["username"]
+        user_data["user"]["fullname"]
+        or user_data["user"]["name"]
+        or user_data["user"]["username"]
         or "<no name specified>"
     )
 
@@ -43,7 +43,7 @@ def handle_new_cfp_submission(data):
             {
                 "type": "section",
                 "text": {
-                    "text": f"New _{submission_type}_ Submission from {user_name}",
+                    "text": f"New _{submission_type}_ Submission by {user_name}",
                     "type": "mrkdwn",
                 },
             }

--- a/backend/domain_events/handler.py
+++ b/backend/domain_events/handler.py
@@ -1,4 +1,16 @@
+from asgiref.sync import async_to_sync
+from django.conf import settings
+from pythonit_toolkit.service_client import ServiceClient
+
 from integrations import slack
+
+USER_NAME_FROM_ID = """query UserNameFromId($userId: ID!) {
+    user(id: $id) {
+        fullname
+        name
+        username
+    }
+}"""
 
 
 def handle_new_cfp_submission(data):
@@ -8,13 +20,30 @@ def handle_new_cfp_submission(data):
     admin_url = data["admin_url"]
     topic = data["topic"]
     duration = data["duration"]
+    author_id = data["author_id"]
+
+    client = ServiceClient(
+        url=f"{settings.USERS_SERVICE}/internal-api",
+        service_name="users-backend",
+        caller="pycon-backend",
+        jwt_secret=settings.SERVICE_TO_SERVICE_SECRET,
+    )
+    client_execute = async_to_sync(client.execute)
+    user_result = client_execute(USER_NAME_FROM_ID, {"userId": author_id})
+    user_data = user_result.data
+    user_name = (
+        user_data["fullname"]
+        or user_data["name"]
+        or user_data["username"]
+        or "<no name specified>"
+    )
 
     slack.send_message(
         [
             {
                 "type": "section",
                 "text": {
-                    "text": f"New _{submission_type}_ Submission",
+                    "text": f"New _{submission_type}_ Submission from {user_name}",
                     "type": "mrkdwn",
                 },
             }

--- a/backend/domain_events/publisher.py
+++ b/backend/domain_events/publisher.py
@@ -28,7 +28,7 @@ def notify_new_submission(
     admin_url: str,
     duration: int,
     topic: str,
-    author_id: int,
+    speaker_id: int,
 ):
     publish_message(
         "NewCFPSubmission",
@@ -39,7 +39,7 @@ def notify_new_submission(
             "admin_url": admin_url,
             "topic": topic,
             "duration": str(duration),
-            "author_id": author_id,
+            "speaker_id": speaker_id,
         },
         deduplication_id=str(submission_id),
     )

--- a/backend/domain_events/publisher.py
+++ b/backend/domain_events/publisher.py
@@ -28,6 +28,7 @@ def notify_new_submission(
     admin_url: str,
     duration: int,
     topic: str,
+    author_id: int,
 ):
     publish_message(
         "NewCFPSubmission",
@@ -38,6 +39,7 @@ def notify_new_submission(
             "admin_url": admin_url,
             "topic": topic,
             "duration": str(duration),
+            "author_id": author_id,
         },
         deduplication_id=str(submission_id),
     )

--- a/backend/domain_events/tests/test_handler.py
+++ b/backend/domain_events/tests/test_handler.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch
 
+import respx
+from django.conf import settings
+
 from domain_events.handler import handle_new_cfp_submission
 
 
@@ -11,9 +14,22 @@ def test_handle_new_cfp_submission():
         "admin_url": "test_admin_url",
         "topic": "test_topic",
         "duration": "50",
+        "speaker_id": 10,
     }
 
-    with patch("domain_events.handler.slack") as slack_mock:
+    with patch("domain_events.handler.slack") as slack_mock, respx.mock as req_mock:
+        req_mock.post(f"{settings.USERS_SERVICE}/internal-api").respond(
+            json={
+                "data": {
+                    "user": {
+                        "fullname": "Marco Acierno",
+                        "name": "Marco",
+                        "username": "marco",
+                    }
+                }
+            }
+        )
         handle_new_cfp_submission(data)
 
     slack_mock.send_message.assert_called_once()
+    assert "Marco Acierno" in str(slack_mock.send_message.mock_calls[0])

--- a/backend/domain_events/tests/test_publisher.py
+++ b/backend/domain_events/tests/test_publisher.py
@@ -43,7 +43,7 @@ def test_notify_new_submission():
             "admin_url": "test_admin_url",
             "topic": "test_topic",
             "duration": "42",
-            "author_id": 10,
+            "speaker_id": 10,
         },
         deduplication_id="1",
     )

--- a/backend/domain_events/tests/test_publisher.py
+++ b/backend/domain_events/tests/test_publisher.py
@@ -31,6 +31,7 @@ def test_notify_new_submission():
             "test_admin_url",
             42,
             "test_topic",
+            10,
         )
 
     mock_publish.assert_called_once_with(
@@ -42,6 +43,7 @@ def test_notify_new_submission():
             "admin_url": "test_admin_url",
             "topic": "test_topic",
             "duration": "42",
+            "author_id": 10,
         },
         deduplication_id="1",
     )

--- a/backend/tests/test_sqs_messages.py
+++ b/backend/tests/test_sqs_messages.py
@@ -2,7 +2,7 @@ import json
 import logging
 from unittest.mock import call, patch
 
-from pytest import fixture
+from pytest import fixture, raises
 
 from sqs_messages import process_sqs_messages
 
@@ -69,17 +69,11 @@ def test_process_sqs_messages_fails_with_exception(mock_boto3, settings, caplog)
 
     fake_handlers = {"Type": fake_handler}
 
-    with patch("sqs_messages.HANDLERS") as handlers:
+    with patch("sqs_messages.HANDLERS") as handlers, raises(
+        ValueError, match="Exception message"
+    ):
         handlers.get = fake_handlers.get
         process_sqs_messages(SQS_MESSAGE_PAYLOAD)
-
-    mock_boto3.client().delete_message.assert_called_once_with(
-        QueueUrl=settings.SQS_QUEUE_URL,
-        ReceiptHandle="82adf785-8fed-4f13-a94a-7f083052371f",
-    )
-    assert caplog.messages == [
-        "Failed to process message_id=376a615c-fcd1-44db-ad39-059bbca4d835 (Type)"
-    ]
 
 
 def test_process_sqs_messages_with_multiple_messages(mock_boto3, settings):

--- a/infrastructure/applications/pycon_backend/queue.tf
+++ b/infrastructure/applications/pycon_backend/queue.tf
@@ -1,6 +1,7 @@
 resource "aws_sqs_queue" "queue" {
-  name       = "${terraform.workspace}-pycon-backend.fifo"
-  fifo_queue = true
+  name                       = "${terraform.workspace}-pycon-backend.fifo"
+  fifo_queue                 = true
+  visibility_timeout_seconds = 60 * 30
 
   tags = {
     Env = terraform.workspace


### PR DESCRIPTION
## Why

1. Submission author in the slack notification
2. Improved how we handle SQS messages. If something goes wrong it will go back in the queue and be processed again after 30 minutes

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Send a submission in the staging frontend, then look at #website-test

https://python-it.slack.com/archives/CLH2C7HAS/p1641941743000300

![image](https://user-images.githubusercontent.com/3382153/149034699-51c2bf15-583f-4d44-900c-77848043db92.png)


<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
