### PR TITLE
Improve order confirmation messages when the payment is pending

### DIFF
--- a/frontend/src/locale/index.ts
+++ b/frontend/src/locale/index.ts
@@ -235,9 +235,16 @@ export const messages = {
       "{roomName} with check-in the {checkin} and check-out the {checkout}",
     "orderConfirmation.heading": "Order confirmation!",
     "orderConfirmation.heading.canceled": "Order canceled!",
+    "orderConfirmation.heading.pending": "Order pending!",
     "orderConfirmation.successMessage":
       "Thanks for the order! You should receive an email confirmation soon!",
+    "orderConfirmation.pendingMessage":
+      "Your order is still pending and not paid! If you paid by card, click the link below and try again",
+    "orderConfirmation.bankMessage": `If you paid via bank transfer, contact us at {email} with your order code {code}
+      once the transfer is done and we will confirm it once we receive the transfer.`,
     "orderConfirmation.manage": "Click here to manage the order.",
+    "orderConfirmation.pendingManage":
+      "Click here to try again or change your payment method.",
     "order.soldout": "Sold out",
     "order.price": "Price: {price} EUR.",
     "order.hotelPrice": "Price: {price}/night EUR.",
@@ -655,8 +662,15 @@ export const messages = {
     "orderConfirmation.manage": "Fai click qui per gestire il tuo ordine.",
     "orderConfirmation.heading": "Ordine confermato",
     "orderConfirmation.heading.canceled": "Ordine cancellato!",
+    "orderConfirmation.heading.pending": "Ordine non processato!",
     "orderConfirmation.successMessage":
       "Grazie per l'ordine, riceverai una email di conferma a breve.",
+    "orderConfirmation.pendingManage":
+      "Clicca qui per riprovare o cambiare metodo di pagamento",
+    "orderConfirmation.pendingMessage":
+      "Il tuo ordine è ancora pending e non confermato! Se hai pagato con card, clicca il link sotto per riprovare",
+    "orderConfirmation.bankMessage": `Se hai pagato con bonifico bancario, contattaci a {email} con il tuo codice {code}
+      appena il bonifico è stato eseguito e confermeremo l'ordine il prima possibile.`,
     "order.soldout": "Sold out",
     "order.price": "Prezzo: {price} EUR",
     "order.hotelPrice": "Price: {price}/notte EUR.",

--- a/frontend/src/locale/index.ts
+++ b/frontend/src/locale/index.ts
@@ -245,6 +245,9 @@ export const messages = {
     "orderConfirmation.manage": "Click here to manage the order.",
     "orderConfirmation.pendingManage":
       "Click here to try again or change your payment method.",
+    "orderConfirmation.tryAgain":
+      "Try again creating a new order going back to our {link} page",
+    "orderConfirmation.tickets": "Tickets",
     "order.soldout": "Sold out",
     "order.price": "Price: {price} EUR.",
     "order.hotelPrice": "Price: {price}/night EUR.",
@@ -671,6 +674,9 @@ export const messages = {
       "Il tuo ordine è ancora pending e non confermato! Se hai pagato con card, clicca il link sotto per riprovare",
     "orderConfirmation.bankMessage": `Se hai pagato con bonifico bancario, contattaci a {email} con il tuo codice {code}
       appena il bonifico è stato eseguito e confermeremo l'ordine il prima possibile.`,
+    "orderConfirmation.tryAgain":
+      "Prova a creare un nuovo ordine nella pagina {link}",
+    "orderConfirmation.tickets": "Biglietti",
     "order.soldout": "Sold out",
     "order.price": "Prezzo: {price} EUR",
     "order.hotelPrice": "Price: {price}/notte EUR.",

--- a/frontend/src/pages/orders/[id]/confirmation.tsx
+++ b/frontend/src/pages/orders/[id]/confirmation.tsx
@@ -37,6 +37,48 @@ const OrderSucceeded = ({ url }: { url: string }) => (
   </React.Fragment>
 );
 
+const OrderPending = ({ url, code }: { url: string; code: string }) => (
+  <React.Fragment>
+    <Heading sx={{ mb: 3 }}>
+      <FormattedMessage id="orderConfirmation.heading.pending" />
+    </Heading>
+    <Text>
+      <FormattedMessage id="orderConfirmation.pendingMessage" />
+    </Text>
+    <Text>
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        <FormattedMessage id="orderConfirmation.pendingManage" />
+      </a>
+    </Text>
+    <Text
+      sx={{
+        mt: 2,
+      }}
+    >
+      <FormattedMessage
+        id="orderConfirmation.bankMessage"
+        values={{
+          code: (
+            <Text
+              as="span"
+              sx={{
+                fontWeight: "bold",
+              }}
+            >
+              {code}
+            </Text>
+          ),
+          email: (
+            <a target="_blank" href="mailto:info@pycon.it">
+              info@pycon.it
+            </a>
+          ),
+        }}
+      />
+    </Text>
+  </React.Fragment>
+);
+
 export const OrderConfirmationPage = () => {
   const [loggedIn, _] = useLoginState();
 
@@ -68,10 +110,10 @@ export const OrderConfirmationPage = () => {
 
   return (
     <Box sx={{ maxWidth: "container", px: 3, mx: "auto" }}>
-      {data.order.status === "CANCELED" ? (
-        <OrderCanceled />
-      ) : (
-        <OrderSucceeded url={data.order.url} />
+      {data.order.status === "CANCELED" && <OrderCanceled />}
+      {data.order.status === "PAID" && <OrderSucceeded url={data.order.url} />}
+      {data.order.status === "PENDING" && (
+        <OrderPending code={code} url={data.order.url} />
       )}
     </Box>
   );

--- a/frontend/src/pages/orders/[id]/confirmation.tsx
+++ b/frontend/src/pages/orders/[id]/confirmation.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/router";
 
 import { addApolloState, getApolloClient } from "~/apollo/client";
 import { Alert } from "~/components/alert";
+import { Link } from "~/components/link";
 import { PageLoading } from "~/components/page-loading";
 import { useLoginState } from "~/components/profile/hooks";
 import { prefetchSharedQueries } from "~/helpers/prefetch";
@@ -20,6 +21,18 @@ const OrderCanceled = () => (
     <Heading sx={{ mb: 3 }}>
       <FormattedMessage id="orderConfirmation.heading.canceled" />
     </Heading>
+    <Text>
+      <FormattedMessage
+        id="orderConfirmation.tryAgain"
+        values={{
+          link: (
+            <Link path="/tickets">
+              <FormattedMessage id="orderConfirmation.tickets" />
+            </Link>
+          ),
+        }}
+      />
+    </Text>
   </React.Fragment>
 );
 
@@ -110,7 +123,8 @@ export const OrderConfirmationPage = () => {
 
   return (
     <Box sx={{ maxWidth: "container", px: 3, mx: "auto" }}>
-      {data.order.status === "CANCELED" && <OrderCanceled />}
+      {(data.order.status === "CANCELED" ||
+        data.order.status === "EXPIRED") && <OrderCanceled />}
       {data.order.status === "PAID" && <OrderSucceeded url={data.order.url} />}
       {data.order.status === "PENDING" && (
         <OrderPending code={code} url={data.order.url} />


### PR DESCRIPTION
## Why

Right now we always say either "Payment confirmed" or "Canceled" even when the order is still in pending status (for whatever reason).
This improves the messages so users are aware if their payment failed for some reason

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Login with my account (ask my on discord my password)
First login: https://pycon-git-web-210-improve-order-checks-aft-2f8b1e-python-italia.vercel.app/en/login
or buy your ticket and cancel/expire them via pretix: https://pycon-git-web-210-improve-order-checks-aft-2f8b1e-python-italia.vercel.app/tickets

Pending order:

https://pycon-git-web-210-improve-order-checks-aft-2f8b1e-python-italia.vercel.app/en/orders/Y3MKP/confirmation

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/3382153/149630364-15cf6b46-94a4-4eab-bb27-5c9dab351240.png">

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/3382153/149630928-a5048732-1052-47f6-a3b0-4fc070359aa1.png">


Paid order:

https://pycon-git-web-210-improve-order-checks-aft-2f8b1e-python-italia.vercel.app/en/orders/R9XTM/confirmation

<img width="952" alt="image" src="https://user-images.githubusercontent.com/3382153/149630399-0321fcce-9325-460f-985a-482b39ff8f0a.png">

<img width="834" alt="image" src="https://user-images.githubusercontent.com/3382153/149630917-87885822-dd8f-41aa-8d3d-3a406ef22b77.png">


Expired / canceled order:

https://pycon-git-web-210-improve-order-checks-aft-2f8b1e-python-italia.vercel.app/en/orders/ZBFTP/confirmation

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/3382153/149630868-be5d838e-4fd6-4944-a954-e8d5441dfb02.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/3382153/149630887-7b9f9ca3-2be1-494f-87d3-8049b8cb76f0.png">


<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
