### PR TITLE
Fix voting filters not working on refresh

### DIFF
--- a/frontend/src/pages/voting/index.tsx
+++ b/frontend/src/pages/voting/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 
 /** @jsx jsx */
-import { useCallback, useState } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { useFormState } from "react-use-form-state";
 import { Flex, Box, Grid, Heading, jsx, Select, Text } from "theme-ui";
@@ -57,12 +57,7 @@ export const VotingPage = () => {
   const router = useRouter();
 
   const [filters, { select, raw }] = useFormState<Filters>(
-    {
-      vote: (router.query.vote as VoteTypes) ?? "all",
-      language: (router.query.language as string) ?? "",
-      topic: (router.query.topic as string) ?? "",
-      tags: getAsArray(router.query.tags),
-    },
+    {},
     {
       onChange(e, stateValues, nextStateValues) {
         setVotedSubmissions(new Set());
@@ -85,6 +80,17 @@ export const VotingPage = () => {
       },
     },
   );
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    filters.setField("vote", router.query.vote ?? "all");
+    filters.setField("language", router.query.language ?? "");
+    filters.setField("topic", router.query.topic ?? "");
+    filters.setField("tags", getAsArray(router.query.tags));
+  }, [router.isReady]);
 
   const filterVisibleSubmissions = (submission) => {
     if (filters.values.topic && submission.topic?.id !== filters.values.topic) {


### PR DESCRIPTION
## Why

Voting filters currently do not work because NextJS first-render has an empty `router.query`. With this fix we make sure we wait for the router to be ready before setting the initial values

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

Go to the voting page
This page should select voted only talks in English with tag Django

http://localhost:3000/en/voting?vote=votedOnly&language=en&tags=3

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
