### PR TITLE
Use Pretix API to check for attendee's ticket

### DIFF
--- a/backend/api/schedule/mutations.py
+++ b/backend/api/schedule/mutations.py
@@ -13,7 +13,7 @@ from api.submissions.permissions import IsSubmissionSpeakerOrStaff
 from conferences.models import Conference
 from domain_events.publisher import send_new_schedule_invitation_answer
 from languages.models import Language
-from pretix.db import user_has_admission_ticket
+from pretix import user_has_admission_ticket
 from schedule.models import Day as DayModel
 from schedule.models import ScheduleItem, ScheduleItemAttendee, Slot
 from submissions.models import Submission

--- a/backend/api/submissions/tests/test_send_submission_comment.py
+++ b/backend/api/submissions/tests/test_send_submission_comment.py
@@ -1,3 +1,4 @@
+import respx
 from pytest import mark
 
 from submissions.models import SubmissionComment
@@ -73,7 +74,11 @@ def test_user_needs_a_ticket_to_comment(
 
     graphql_client.force_login(user)
 
-    resp = _send_comment(graphql_client, submission, "Hello world!")
+    with respx.mock as mock:
+        mock.post(f"{settings.ASSOCIATION_BACKEND_SERVICE}/internal-api").respond(
+            json={"data": {"userIdIsMember": False}}
+        )
+        resp = _send_comment(graphql_client, submission, "Hello world!")
 
     assert resp["errors"][0]["message"] == "You can't send a comment"
 

--- a/backend/api/submissions/tests/test_send_submission_comment.py
+++ b/backend/api/submissions/tests/test_send_submission_comment.py
@@ -42,7 +42,7 @@ def test_send_comment(
 ):
     conference = submission.conference
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -68,7 +68,7 @@ def test_user_needs_a_ticket_to_comment(
     submission = submission_factory()
     conference = submission.conference
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": False},
     )
 
@@ -147,7 +147,7 @@ def test_cannot_send_empty_comment(
 ):
     conference = submission.conference
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 

--- a/backend/api/submissions/tests/test_send_submission_comment.py
+++ b/backend/api/submissions/tests/test_send_submission_comment.py
@@ -36,7 +36,15 @@ def _send_comment(client, submission, text):
 
 
 @mark.django_db
-def test_send_comment(graphql_client, user, submission, mocker):
+def test_send_comment(
+    graphql_client, user, submission, mocker, requests_mock, settings
+):
+    conference = submission.conference
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
+
     mocker.patch("notifications.aws.send_notification")
 
     graphql_client.force_login(user)
@@ -54,12 +62,14 @@ def test_send_comment(graphql_client, user, submission, mocker):
 
 @mark.django_db
 def test_user_needs_a_ticket_to_comment(
-    graphql_client, user, submission_factory, mocker
+    graphql_client, user, submission_factory, requests_mock, settings
 ):
     submission = submission_factory()
-    mocker.patch(
-        "api.submissions.permissions.pastaporto_user_info_can_vote"
-    ).return_value = False
+    conference = submission.conference
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": False},
+    )
 
     graphql_client.force_login(user)
 
@@ -127,7 +137,15 @@ def test_user_can_send_comment_to_own_submission(
     assert resp["data"]["sendSubmissionComment"]["__typename"] == "SubmissionComment"
 
 
-def test_cannot_send_empty_comment(graphql_client, user, submission):
+def test_cannot_send_empty_comment(
+    graphql_client, user, submission, requests_mock, settings
+):
+    conference = submission.conference
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
+
     graphql_client.force_login(user)
 
     resp = _send_comment(graphql_client, submission, "")

--- a/backend/api/submissions/tests/test_submission.py
+++ b/backend/api/submissions/tests/test_submission.py
@@ -107,7 +107,7 @@ def test_get_submission_comments(
     conference = comment.submission.conference
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -148,7 +148,7 @@ def test_get_submission_comments_returns_speaker_as_name(
 ):
     conference = submission.conference
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 

--- a/backend/api/submissions/tests/test_submission.py
+++ b/backend/api/submissions/tests/test_submission.py
@@ -98,10 +98,18 @@ def test_can_edit_submission_if_cfp_is_closed(graphql_client, user, submission_f
 
 
 @mark.django_db
-def test_get_submission_comments(graphql_client, user, submission_comment_factory):
+def test_get_submission_comments(
+    graphql_client, user, submission_comment_factory, requests_mock, settings
+):
     graphql_client.force_login(user)
 
     comment = submission_comment_factory()
+    conference = comment.submission.conference
+
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
 
     response = graphql_client.query(
         """
@@ -131,8 +139,19 @@ def test_get_submission_comments(graphql_client, user, submission_comment_factor
 
 @mark.django_db
 def test_get_submission_comments_returns_speaker_as_name(
-    graphql_client, user, submission, submission_comment_factory
+    graphql_client,
+    user,
+    submission,
+    submission_comment_factory,
+    requests_mock,
+    settings,
 ):
+    conference = submission.conference
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
+
     graphql_client.force_login(user)
 
     comment = submission_comment_factory(

--- a/backend/api/tests/schema/conference/test_conference.py
+++ b/backend/api/tests/schema/conference/test_conference.py
@@ -708,7 +708,7 @@ def test_filter_submission_by_status(
     graphql_client, submission_factory, conference, user, requests_mock, settings
 ):
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 

--- a/backend/api/tests/schema/conference/test_conference.py
+++ b/backend/api/tests/schema/conference/test_conference.py
@@ -705,9 +705,13 @@ def test_get_conference_voucher_with_invalid_code(graphql_client, conference, mo
 
 @mark.django_db
 def test_filter_submission_by_status(
-    graphql_client, submission_factory, conference, mocker, user
+    graphql_client, submission_factory, conference, user, requests_mock, settings
 ):
-    mocker.patch("voting.helpers.pastaporto_user_info_can_vote", return_value=True)
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
+
     submission_factory(conference=conference, status="cancelled")
     submission_factory(conference=conference, status="proposed")
     graphql_client.force_login(user)

--- a/backend/newsletters/exporter.py
+++ b/backend/newsletters/exporter.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from django.db.models import Q
 
 from conferences.models import Conference
-from pretix.db import user_has_admission_ticket
+from pretix import user_has_admission_ticket
 from schedule.models import ScheduleItem
 from submissions.models import Submission
 from users.models import User

--- a/backend/pretix/__init__.py
+++ b/backend/pretix/__init__.py
@@ -357,7 +357,7 @@ class Conference:
 
 
 def user_has_admission_ticket(
-    *, email: str, event_organizer: str, event_slug: int
+    *, email: str, event_organizer: str, event_slug: str
 ) -> bool:
     response = pretix(
         conference=Conference(

--- a/backend/pretix/__init__.py
+++ b/backend/pretix/__init__.py
@@ -363,7 +363,7 @@ def user_has_admission_ticket(
         conference=Conference(
             pretix_organizer_id=event_organizer, pretix_event_id=event_slug
         ),
-        endpoint="tickets/attendee-has-ticket",
+        endpoint="tickets/attendee-has-ticket/",
         method="post",
         json={
             "attendee_email": email,
@@ -376,6 +376,7 @@ def user_has_admission_ticket(
             ],
         },
     )
+
     response.raise_for_status()
     data = response.json()
     return data["user_has_admission_ticket"]

--- a/backend/pretix/db.py
+++ b/backend/pretix/db.py
@@ -1,42 +1,9 @@
-from dataclasses import dataclass
 from typing import List, Optional
 
 from django.conf import settings
 from django.db import connections
 
 from api.pretix.types import Voucher
-from pretix import pretix
-
-
-@dataclass
-class Conference:
-    pretix_organizer_id: str
-    pretix_event_id: str
-
-
-def user_has_admission_ticket(
-    *, email: str, event_organizer: str, event_slug: int
-) -> bool:
-    response = pretix(
-        conference=Conference(
-            pretix_organizer_id=event_organizer, pretix_event_id=event_slug
-        ),
-        endpoint="tickets/attendee-has-ticket",
-        method="post",
-        json={
-            "attendee_email": email,
-            # TODO: In the future this method should be changed to send multiple events
-            "events": [
-                {
-                    "organizer_slug": event_organizer,
-                    "event_slug": event_slug,
-                }
-            ],
-        },
-    )
-    response.raise_for_status()
-    data = response.json()
-    return data["user_has_admission_ticket"]
 
 
 def get_orders_status(orders: List[str]):

--- a/backend/pretix/tests/test_user_has_ticket.py
+++ b/backend/pretix/tests/test_user_has_ticket.py
@@ -13,7 +13,7 @@ def test_user_has_admission_ticket(
     conference = conference_factory()
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": has_ticket},
     )
 

--- a/backend/pretix/tests/test_user_has_ticket.py
+++ b/backend/pretix/tests/test_user_has_ticket.py
@@ -9,11 +9,11 @@ pytestmark = mark.django_db
 def test_user_has_admission_ticket(
     settings, has_ticket, conference_factory, requests_mock
 ):
-    settings.PRETIX_API = "http://localhost:9090"
+    settings.PRETIX_API = "http://localhost:9090/"
     conference = conference_factory()
 
     requests_mock.post(
-        f"{settings.PRETIX_API}/organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
         json={"user_has_admission_ticket": has_ticket},
     )
 

--- a/backend/pretix/tests/test_user_has_ticket.py
+++ b/backend/pretix/tests/test_user_has_ticket.py
@@ -1,34 +1,37 @@
-from django.test import override_settings
 from pytest import mark
 
 from pretix.db import user_has_admission_ticket
 
-
-@override_settings(SIMULATE_PRETIX_DB=True)
-def test_user_always_has_ticket_when_db_is_simulated():
-    assert (
-        user_has_admission_ticket(
-            email="nina@fake-work-email.ca",
-            event_organizer="organizer",
-            event_slug="event",
-        )
-        is True
-    )
+pytestmark = mark.django_db
 
 
-@override_settings(SIMULATE_PRETIX_DB=False)
 @mark.parametrize("has_ticket", [True, False])
-def test_user_has_admission_ticket(mocker, has_ticket):
-    connections_mock = mocker.patch("pretix.db.connections")
-    connections_mock.__getitem__.return_value.cursor.return_value.__enter__.return_value.fetchone.return_value = (  # noqa
-        has_ticket,
+def test_user_has_admission_ticket(
+    settings, has_ticket, conference_factory, requests_mock
+):
+    settings.PRETIX_API = "http://localhost:9090"
+    conference = conference_factory()
+
+    requests_mock.post(
+        f"{settings.PRETIX_API}/organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": has_ticket},
     )
 
     assert (
         user_has_admission_ticket(
             email="nina@fake-work-email.ca",
-            event_organizer="organizer",
-            event_slug="slug",
+            event_organizer=conference.pretix_organizer_id,
+            event_slug=conference.pretix_event_id,
         )
         is has_ticket
     )
+
+    assert requests_mock.last_request.json() == {
+        "attendee_email": "nina@fake-work-email.ca",
+        "events": [
+            {
+                "organizer_slug": conference.pretix_organizer_id,
+                "event_slug": conference.pretix_event_id,
+            }
+        ],
+    }

--- a/backend/pretix/tests/test_user_has_ticket.py
+++ b/backend/pretix/tests/test_user_has_ticket.py
@@ -1,6 +1,6 @@
 from pytest import mark
 
-from pretix.db import user_has_admission_ticket
+from pretix import user_has_admission_ticket
 
 pytestmark = mark.django_db
 

--- a/backend/pycon/settings/test.py
+++ b/backend/pycon/settings/test.py
@@ -15,3 +15,5 @@ SERVICE_TO_SERVICE_SECRET = "secret-to-secret"
 MAILCHIMP_SECRET_KEY = "super-secret-key-for-tests"
 MAILCHIMP_DC = "us5"
 MAILCHIMP_LIST_ID = "12345678ab"
+
+PRETIX_API = "http://pretix-api:9000/"

--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -17,7 +17,7 @@ from domain_events.publisher import (
     send_new_submission_time_slot,
     send_schedule_invitation_email,
 )
-from pretix.db import user_has_admission_ticket
+from pretix import user_has_admission_ticket
 from users.autocomplete import UsersBackendAutocomplete
 from users.mixins import AdminUsersMixin, ResourceUsersByIdsMixin
 

--- a/backend/voting/helpers.py
+++ b/backend/voting/helpers.py
@@ -4,7 +4,7 @@ from pythonit_toolkit.pastaporto.entities import Pastaporto
 from pythonit_toolkit.service_client import ServiceClient
 
 from conferences.models import Conference
-from pretix.db import user_has_admission_ticket
+from pretix import user_has_admission_ticket
 from submissions.models import Submission
 
 IS_USER_MEMBER_OF_PYTHON_ITALIA = """query($userId: ID!) {

--- a/backend/voting/tests/test_schema.py
+++ b/backend/voting/tests/test_schema.py
@@ -9,7 +9,7 @@ def test_get_logged_user_vote_on_a_submission(
     conference = vote.submission.conference
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -65,7 +65,7 @@ def test_get_my_vote_when_the_user_never_voted(
     conference = submission.conference
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 

--- a/backend/voting/tests/test_send_vote.py
+++ b/backend/voting/tests/test_send_vote.py
@@ -57,7 +57,7 @@ def test_submit_vote(
     submission = submission_factory(conference=conference)
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -79,7 +79,7 @@ def test_reject_vote_when_voting_is_not_open(
 
     conference = conference_factory()
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -100,7 +100,7 @@ def test_user_can_vote_different_submissions(
 
     conference = conference_factory(active_voting=True)
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -132,7 +132,7 @@ def test_updating_vote_when_user_votes_the_same_submission(
     conference = conference_factory(active_voting=True)
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": True},
     )
 
@@ -161,7 +161,7 @@ def test_cannot_vote_without_a_ticket_or_membership(
     conference = submission.conference
 
     requests_mock.post(
-        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket/",
         json={"user_has_admission_ticket": False},
     )
 

--- a/backend/voting/tests/test_send_vote.py
+++ b/backend/voting/tests/test_send_vote.py
@@ -43,13 +43,23 @@ def _submit_vote(client, submission, **kwargs):
 @mark.django_db
 @mark.parametrize("score_index", [1, 2, 3, 4])
 def test_submit_vote(
-    graphql_client, user, conference_factory, submission_factory, score_index
+    graphql_client,
+    user,
+    conference_factory,
+    submission_factory,
+    score_index,
+    requests_mock,
 ):
     graphql_client.force_login(user)
 
     conference = conference_factory(active_voting=True)
 
     submission = submission_factory(conference=conference)
+
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
 
     resp, variables = _submit_vote(graphql_client, submission, value_index=score_index)
 
@@ -63,11 +73,15 @@ def test_submit_vote(
 
 
 def test_reject_vote_when_voting_is_not_open(
-    graphql_client, user, conference_factory, submission_factory
+    graphql_client, user, conference_factory, submission_factory, requests_mock
 ):
     graphql_client.force_login(user)
 
     conference = conference_factory()
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
 
     submission = submission_factory(conference=conference)
 
@@ -80,11 +94,15 @@ def test_reject_vote_when_voting_is_not_open(
 
 
 def test_user_can_vote_different_submissions(
-    graphql_client, user, conference_factory, submission_factory
+    graphql_client, user, conference_factory, submission_factory, requests_mock
 ):
     graphql_client.force_login(user)
 
     conference = conference_factory(active_voting=True)
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
 
     submission1 = submission_factory(conference=conference)
     resp1, variables1 = _submit_vote(graphql_client, submission1)
@@ -107,11 +125,16 @@ def test_user_can_vote_different_submissions(
 
 
 def test_updating_vote_when_user_votes_the_same_submission(
-    graphql_client, user, conference_factory, submission_factory
+    graphql_client, user, conference_factory, submission_factory, requests_mock
 ):
     graphql_client.force_login(user)
 
     conference = conference_factory(active_voting=True)
+
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": True},
+    )
 
     submission = submission_factory(conference=conference, id=1)
     resp, variables = _submit_vote(graphql_client, submission, value_index=1)
@@ -131,12 +154,15 @@ def test_updating_vote_when_user_votes_the_same_submission(
 
 
 def test_cannot_vote_without_a_ticket_or_membership(
-    graphql_client, user, mocker, submission_factory
+    graphql_client, user, submission_factory, requests_mock
 ):
     graphql_client.force_login(user)
     submission = submission_factory(conference__active_voting=True)
-    admission_ticket_mock = mocker.patch(
-        "voting.helpers.user_has_admission_ticket", return_value=False
+    conference = submission.conference
+
+    requests_mock.post(
+        f"{settings.PRETIX_API}organizers/{conference.pretix_organizer_id}/events/{conference.pretix_event_id}/tickets/attendee-has-ticket",
+        json={"user_has_admission_ticket": False},
     )
 
     with respx.mock as mock:
@@ -150,8 +176,6 @@ def test_cannot_vote_without_a_ticket_or_membership(
     assert resp["data"]["sendVote"]["nonFieldErrors"] == [
         "You cannot vote without a ticket"
     ]
-
-    admission_ticket_mock.assert_called()
 
     with raises(Vote.DoesNotExist):
         Vote.objects.get(user_id=user.id, submission=submission)


### PR DESCRIPTION
## Why

We are getting rid of direct DB calls to integrate with Pretix to allow us to test APIs locally and on staging (both do not have access to the pretix DB)

We implemented an API on pretix to check if a person has a ticket, this PR now remove the DB equivalent and uses that API

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->

## How to test it

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
