### PR TITLE
Add better design for schedule on mobile

### DIFF
--- a/frontend/src/components/schedule-view/events.tsx
+++ b/frontend/src/components/schedule-view/events.tsx
@@ -192,7 +192,8 @@ export const ScheduleEntry: React.SFC<{
         zIndex: ["scheduleDraggable"],
         backgroundColor,
         position: "relative",
-        p: 2,
+        px: 20,
+        py: 3,
         fontSize: 1,
       }}
       {...props}
@@ -204,7 +205,7 @@ export const ScheduleEntry: React.SFC<{
           color: "inherit",
           textDecoration: "none",
           height: "100%",
-          maxHeight: 135,
+          maxHeight: [null, 135],
           display: "block",
           "> span": {
             height: "100%",
@@ -214,6 +215,18 @@ export const ScheduleEntry: React.SFC<{
         }}
       >
         <Text>
+          {item.type !== "custom" ? (
+            <Text
+              sx={{
+                fontWeight: "bold",
+                display: [null, "block"],
+                mb: 2,
+              }}
+            >
+              {item.rooms.map((room) => room.name).join(", ")}
+            </Text>
+          ) : null}
+
           {item.title}
 
           {marker && (
@@ -230,7 +243,7 @@ export const ScheduleEntry: React.SFC<{
               item.type === "keynote" || item.type === "talk"
                 ? "black"
                 : "white",
-            mt: "auto",
+            mt: ["20px", "auto"],
           }}
         >
           <Box sx={{ mr: "auto" }}>

--- a/frontend/src/components/schedule-view/placeholder.tsx
+++ b/frontend/src/components/schedule-view/placeholder.tsx
@@ -58,6 +58,7 @@ export const Placeholder: React.SFC<{
         backgroundColor,
         p: 2,
         fontSize: 1,
+        display: ["none", "block"],
       }}
     >
       {adminMode && `Placeholder ${duration}`}

--- a/frontend/src/components/schedule-view/schedule.tsx
+++ b/frontend/src/components/schedule-view/schedule.tsx
@@ -3,7 +3,7 @@
 /** @jsx jsx */
 import React, { useRef } from "react";
 import useSyncScroll from "react-use-sync-scroll";
-import { Box, Grid, jsx } from "theme-ui";
+import { Box, jsx } from "theme-ui";
 
 import { ScheduleEntry } from "./events";
 import { isTraining } from "./is-training";
@@ -137,18 +137,19 @@ const GridContainer = React.forwardRef<
     ref={ref}
     {...props}
   >
-    <Grid
-      gap={"4px"}
+    <div
       sx={{
-        minWidth: "2000px",
+        minWidth: [null, "2000px"],
         gridTemplateColumns: `80px repeat(${totalColumns}, 1fr)`,
         gridTemplateRows: `repeat(${totalRows - 1}, 10px)`,
         py: "4px",
         backgroundColor: "black",
+        gap: "4px",
+        display: ["block", "grid"],
       }}
     >
       {children}
-    </Grid>
+    </div>
   </Box>
 ));
 
@@ -226,6 +227,7 @@ export const Schedule: React.SFC<{
           zIndex: ["scheduleHeader"],
           overflowX: "hidden",
           mb: "-4px",
+          display: ["none", "grid"],
         }}
       >
         <Box
@@ -268,7 +270,7 @@ export const Schedule: React.SFC<{
           const rowEnd = getRowEndForSlot(slotIndex);
 
           return (
-            <React.Fragment key={slot.id}>
+            <div sx={{ display: "contents" }} key={slot.id}>
               <Box
                 sx={{
                   gridColumnStart: 1,
@@ -276,8 +278,8 @@ export const Schedule: React.SFC<{
                   gridRowStart: "var(--start)",
                   gridRowEnd: "var(--end)",
                   backgroundColor: "white",
-                  p: 2,
-                  textAlign: "center",
+                  p: [3, 2],
+                  textAlign: [null, "center"],
                   fontWeight: "bold",
                 }}
                 style={
@@ -327,7 +329,7 @@ export const Schedule: React.SFC<{
                   }
                 />
               ))}
-            </React.Fragment>
+            </div>
           );
         })}
       </GridContainer>


### PR DESCRIPTION
This PR adds a better layout for mobile: 

<img width="601" alt="image" src="https://user-images.githubusercontent.com/667029/168136189-6ada9cbf-e992-4f29-a219-894e8bb1727a.png">

I should do another version for mid-sizes devices, but that's for another PR 😊