### PR TITLE
Grants Replies: do not save need_info

### DIFF
--- a/backend/api/grants/mutations.py
+++ b/backend/api/grants/mutations.py
@@ -231,14 +231,14 @@ class GrantMutation:
                 message=f"The status `{input.status}` is not valid for this grant"
             )
 
-        if not GrantModel.Status.needs_info:
+        if input.status != GrantModel.Status.needs_info:
             grant.status = input.status
+        else:
+            send_grant_need_info_email(grant)
 
         grant.applicant_message = input.message
         grant.save()
 
         notify_new_grant_reply(grant, request)
-        if grant.status == GrantModel.Status.needs_info:
-            send_grant_need_info_email(grant)
 
         return Grant.from_model(grant)

--- a/backend/api/grants/mutations.py
+++ b/backend/api/grants/mutations.py
@@ -231,7 +231,9 @@ class GrantMutation:
                 message=f"The status `{input.status}` is not valid for this grant"
             )
 
-        grant.status = input.status
+        if not GrantModel.Status.needs_info:
+            grant.status = input.status
+
         grant.applicant_message = input.message
         grant.save()
 

--- a/backend/api/users/types.py
+++ b/backend/api/users/types.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from typing import List, Optional
 
 import strawberry
@@ -12,6 +13,8 @@ from conferences.models import Conference
 from grants.models import Grant as GrantModel
 from participants.models import Participant as ParticipantModel
 from submissions.models import Submission as SubmissionModel
+
+logger = getLogger(__name__)
 
 
 @strawberry.federation.type(keys=["id"], extend=True)
@@ -31,6 +34,9 @@ class User:
         grant = GrantModel.objects.filter(
             user_id=self.id, conference__code=conference
         ).first()
+        logger.info(
+            "Grant: user_id: %s, conference: %s, grant: %s", self.id, conference, grant
+        )
         return Grant.from_model(grant) if grant else None
 
     @strawberry.field

--- a/backend/domain_events/handler.py
+++ b/backend/domain_events/handler.py
@@ -163,12 +163,18 @@ def handle_new_grant_reply(data):
     grant = Grant.objects.get(id=data["grant_id"])
     admin_url = data["admin_url"]
 
+    actions = []
+    if grant.applicant_message:
+        actions.append("sent a message")
+    if grant.status in (Grant.Status.confirmed, Grant.Status.refused):
+        actions.append(f"{Grant.Status(grant.status).label} the grant")
+
     slack.send_message(
         [
             {
                 "type": "section",
                 "text": {
-                    "text": f"{grant.full_name} {Grant.Status(grant.status).label} the grant",
+                    "text": f"{grant.full_name} {' and '.join(actions)}",
                     "type": "mrkdwn",
                 },
             }

--- a/frontend/src/pages/grants/reply/index.tsx
+++ b/frontend/src/pages/grants/reply/index.tsx
@@ -69,14 +69,17 @@ const GrantReply = () => {
   const [
     sendGrantReply,
     { loading: isSubmitting, error: replyError, data: replyData },
-  ] = useSendGrantReplyMutation({});
+  ] = useSendGrantReplyMutation({
+    onError(err) {
+      console.error(err.message);
+    },
+  });
 
   const grant = data && data?.me?.grant;
 
   const submitReply = useCallback(
     (e) => {
       e.preventDefault();
-      console.log("grant.id:", grant);
       sendGrantReply({
         variables: {
           input: {
@@ -102,6 +105,9 @@ const GrantReply = () => {
   }
 
   const hasSentAnswer = ANSWERS_STATUSES.includes(grant?.status) ?? false;
+  const answerHasChanged =
+    grant?.status !== formState.values.option ||
+    grant?.applicantMessage !== formState.values.message;
 
   if (error) {
     return (
@@ -209,7 +215,12 @@ const GrantReply = () => {
           )}
         </Flex>
 
-        <Button onClick={submitReply} disabled={!formState.values.option}>
+        <Button
+          onClick={submitReply}
+          disabled={
+            !formState.values.option || !answerHasChanged || isSubmitting
+          }
+        >
           <FormattedMessage id="grants.reply.submitReply" />
         </Button>
         {isSubmitting && (
@@ -220,6 +231,14 @@ const GrantReply = () => {
         {!isSubmitting && replyData?.sendGrantReply.__typename === "Grant" && (
           <Alert variant="success">
             <FormattedMessage id="grants.reply.replySentWithSuccess" />
+          </Alert>
+        )}
+        {(replyError ||
+          replyData?.sendGrantReply.__typename === "SendGrantReplyError") && (
+          <Alert variant="alert">
+            <Text>
+              {replyError.message || replyData?.sendGrantReply.__typename}
+            </Text>
           </Alert>
         )}
       </Section>


### PR DESCRIPTION

## Why

<!-- 
Explain here why this change is being done, reference any tickets and anything else that gives context on this PR.
Make sure the reviewer has everything they need to review the code, either written here or in some GitHub comments.
!-->
If the user reply with `need_info` and we update the status we will lose the original status! 
We will not know anymore if the grant was in the Approved or in the Maybe list... 
So it's enough to save the message and leave the status as it was. 
We will update the status only if it's Refused or Confirmed. 

We don't have a History of the status (don't know if it's worth it)...
## How to test it

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
