### PR TITLE
Missing text in the italian language

### DIFF
--- a/frontend/src/locale/index.ts
+++ b/frontend/src/locale/index.ts
@@ -1570,6 +1570,7 @@ Il tuo voto ci aiuterà a creare un programma che più rispecchia ciò che la co
     "tickets.checkout.payWithBankTransfer": "Paga con bonifico",
     "tickets.checkout.savedAmount": "Hai risparmiato {amount}",
 
+    "scheduleEventDetail.sidebar.spacesLeft": "Posti liberi",
     "scheduleEvent.soldout": "Sold-out",
 
     "tickets.checkout.voucher.fetching": "Verifica codice sconto...",


### PR DESCRIPTION
## Why
On the workshop pages, the space left info is rendered as follows:

![immagine](https://user-images.githubusercontent.com/3239064/226174423-34e284f2-c478-4332-a746-a69173d89cc0.png)


## How to test it
