### PR TITLE
Increase lambda timeout to 60 seconds

### DIFF
--- a/infrastructure/components/application_lambda/main.tf
+++ b/infrastructure/components/application_lambda/main.tf
@@ -10,7 +10,7 @@ locals {
 resource "aws_lambda_function" "lambda" {
   function_name = local.lambda_name
   role          = var.role_arn
-  timeout       = 30
+  timeout       = 60
   memory_size   = var.memory_size
   package_type  = "Image"
   image_uri     = local.image_uri


### PR DESCRIPTION
I think our invoice sync is taking more than 30 seconds (it works fine locally), so I've increase the timeout for the lambda.

We'll have a better sync for next year :D