### PR TITLE
Grants admin: Add column for Confirmed and Proposed speakers

### DIFF
--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -521,7 +521,7 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
             submission__speaker_id__isnull=False,
         ).values_list("submission__speaker_id", flat=True)
 
-        # Fetch speakers who proposed a talk (not confirmed)
+        # Fetch speakers who proposed a submission (not confirmed)
         self.proposed_speaker_ids = Submission.objects.filter(
             conference__id__in=all_conference_ids,
         ).values_list("speaker_id", flat=True)

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -25,8 +25,8 @@ from grants.tasks import (
 from pretix import create_voucher
 from schedule.models import ScheduleItem
 from submissions.models import Submission
-from conferences.models import Conference
 from .models import Grant
+from django.db.models import Exists, OuterRef
 
 
 EXPORT_GRANTS_FIELDS = (
@@ -364,8 +364,6 @@ class GrantAdminForm(forms.ModelForm):
 @admin.register(Grant)
 class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     change_list_template = "admin/grants/grant/change_list.html"
-    confirmed_speaker_ids = []
-    proposed_speaker_ids = []
     resource_class = GrantResource
     form = GrantAdminForm
     list_display = (
@@ -493,39 +491,37 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
 
         return ""
 
-    @admin.display(description="🗣️")
-    def is_confirmed_speaker(self, obj):
-        if obj.user_id in self.confirmed_speaker_ids:
-            return "🗣️"
-        return ""
-
     @admin.display(description="✍️")
     def is_proposed_speaker(self, obj):
-        if obj.user_id in self.proposed_speaker_ids:
+        if obj.is_proposed_speaker:
             return "✍️"
         return ""
 
+    @admin.display(description="🗣️")
+    def is_confirmed_speaker(self, obj):
+        if obj.is_confirmed_speaker:
+            return "🗣️"
+        return ""
+
     def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        conference_id = request.GET.get("conference__id__exact")
-
-        # If a specific conference is not filtered, fetch all relevant conference IDs
-        if not conference_id:
-            all_conference_ids = Conference.objects.all().values_list("id", flat=True)
-        else:
-            all_conference_ids = [conference_id]
-
-        # Fetch confirmed speakers (those in the Schedule)
-        self.confirmed_speaker_ids = ScheduleItem.objects.filter(
-            conference__id__in=all_conference_ids,
-            submission__speaker_id__isnull=False,
-        ).values_list("submission__speaker_id", flat=True)
-
-        # Fetch speakers who proposed a submission (not confirmed)
-        self.proposed_speaker_ids = Submission.objects.filter(
-            conference__id__in=all_conference_ids,
-        ).values_list("speaker_id", flat=True)
-
+        qs = (
+            super()
+            .get_queryset(request)
+            .annotate(
+                is_proposed_speaker=Exists(
+                    Submission.objects.non_cancelled().filter(
+                        conference_id=OuterRef("conference_id"),
+                        speaker_id=OuterRef("user_id"),
+                    )
+                ),
+                is_confirmed_speaker=Exists(
+                    ScheduleItem.objects.filter(
+                        conference_id=OuterRef("conference_id"),
+                        submission__speaker_id=OuterRef("user_id"),
+                    )
+                ),
+            )
+        )
         return qs
 
     def save_form(self, request, form, change):

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -371,8 +371,8 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     list_display = (
         "user_display_name",
         "country",
-        "is_confirmed_speaker",
         "is_proposed_speaker",
+        "is_confirmed_speaker",
         "conference",
         "status",
         "approved_type",

--- a/backend/grants/templates/admin/grants/grant/change_list.html
+++ b/backend/grants/templates/admin/grants/grant/change_list.html
@@ -6,24 +6,7 @@
     </li>
     {{ block.super }}
 {% endblock %}
-{% block extrastyle %}
-    <style>
-  th[title]:hover:after {
-      content: attr(title);
-      padding: 4px 8px;
-      color: #fff;
-      position: absolute;
-      left: 50%;
-      bottom: 100%;
-      white-space: nowrap;
-      z-index: 1000;
-      background-color: #333;
-      border-radius: 6px;
-      box-shadow: 0px 0px 10px #000;
-  }
-    </style>
-    {{ block.super }}
-{% endblock %}
+
 {% block extrahead %}
     {{ block.super }}
     <script type="text/javascript">

--- a/backend/grants/templates/admin/grants/grant/change_list.html
+++ b/backend/grants/templates/admin/grants/grant/change_list.html
@@ -1,7 +1,39 @@
 {% extends "admin/change_list.html" %}
 {% block object-tools-items %}
     <li>
-        <a href="{% url 'admin:grants-summary' %}?{{ request.GET.urlencode }}" class="button">Grant Summary</a>
+        <a href="{% url 'admin:grants-summary' %}?{{ request.GET.urlencode }}"
+           class="button">Grant Summary</a>
     </li>
     {{ block.super }}
+{% endblock %}
+{% block extrastyle %}
+    <style>
+  th[title]:hover:after {
+      content: attr(title);
+      padding: 4px 8px;
+      color: #fff;
+      position: absolute;
+      left: 50%;
+      bottom: 100%;
+      white-space: nowrap;
+      z-index: 1000;
+      background-color: #333;
+      border-radius: 6px;
+      box-shadow: 0px 0px 10px #000;
+  }
+    </style>
+    {{ block.super }}
+{% endblock %}
+{% block extrahead %}
+    {{ block.super }}
+    <script type="text/javascript">
+  window.addEventListener('load', function() {
+      // Add tooltips
+      const headers = document.querySelectorAll('.column-is_confirmed_speaker, .column-is_proposed_speaker');
+      headers.forEach(header => {
+          const text = header.textContent;
+          header.setAttribute('title', text.trim() === '🗣️' ? 'Confirmed Speaker' : 'Proposed Speaker');
+      });
+  });
+    </script>
 {% endblock %}


### PR DESCRIPTION
## Why

To know if the Grant applicant has proposed a talk or not (at this stage the talks are not in the schedule yet). 
I modified the existing column to be "is_confirmed_talk" and added a new one "is_proposed_talk". 
As this column is just an emoji I added a tooltip custom in the admin so the user can go hover the title column and see the extended name of the column...    Django unfortunately doesn't have this functionality by default. 

## How to test it

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
