### PR TITLE
Fix various deprecations / warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/backend/api/blog/schema.py
+++ b/backend/api/blog/schema.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from api.context import Info
 
 import strawberry
 
@@ -11,7 +12,7 @@ from .types import Post as PostType
 @strawberry.type
 class BlogQuery:
     @strawberry.field
-    def blog_posts(self, info) -> List[PostType]:
+    def blog_posts(self, info: Info) -> List[PostType]:
         return [
             PostType(
                 id=post.id,
@@ -33,7 +34,7 @@ class BlogQuery:
         ]
 
     @strawberry.field
-    def blog_post(self, info, slug: str) -> Optional[PostType]:
+    def blog_post(self, info: Info, slug: str) -> Optional[PostType]:
         post = Post.published_posts.by_slug(slug).first()
 
         if not post:

--- a/backend/api/cms/types.py
+++ b/backend/api/cms/types.py
@@ -1,4 +1,5 @@
 import typing
+from api.context import Info
 
 import strawberry
 from strawberry import ID
@@ -27,5 +28,5 @@ class Menu:
     title: str = strawberry.field(resolver=make_localized_resolver("title"))
 
     @strawberry.field
-    def links(self, info) -> typing.List[MenuLink]:
+    def links(self, info: Info) -> typing.List[MenuLink]:
         return self.links.all()

--- a/backend/api/conferences/schema.py
+++ b/backend/api/conferences/schema.py
@@ -1,3 +1,4 @@
+from api.context import Info
 import strawberry
 
 from conferences.models import Conference
@@ -8,5 +9,5 @@ from . import types
 @strawberry.type
 class ConferenceQuery:
     @strawberry.field
-    def conference(self, info, code: str) -> types.Conference:
+    def conference(self, info: Info, code: str) -> types.Conference:
         return Conference.objects.prefetch_related("durations").get(code=code)

--- a/backend/api/countries/schema.py
+++ b/backend/api/countries/schema.py
@@ -1,4 +1,5 @@
 from typing import List
+from api.context import Info
 
 import strawberry
 
@@ -9,11 +10,11 @@ from countries import countries
 @strawberry.type
 class CountryQuery:
     @strawberry.field
-    def countries(self, info) -> List[Country]:
+    def countries(self, info: Info) -> List[Country]:
         return [Country(code=country.code, name=country.name) for country in countries]
 
     @strawberry.field
-    def country(self, info, code: str = "") -> Country:
+    def country(self, info: Info, code: str = "") -> Country:
         country = countries.get(code=code)
         if not country:
             raise ValueError(f"'{code}' is not a valid country.")

--- a/backend/api/helpers/images.py
+++ b/backend/api/helpers/images.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
+from api.context import Info
 
-def resolve_image(root, info) -> Optional[str]:
+
+def resolve_image(root, info: Info) -> Optional[str]:
     if not root.image:
         return None
 

--- a/backend/api/helpers/maps.py
+++ b/backend/api/helpers/maps.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from typing import Optional
+from api.context import Info
 
 import strawberry
 from django.conf import settings
@@ -44,7 +45,7 @@ class Map:
         )
 
 
-def resolve_map(root, info) -> Optional[Map]:
+def resolve_map(root, info: Info) -> Optional[Map]:
     if not all((root.latitude, root.longitude)):
         return None
 

--- a/backend/api/job_board/types.py
+++ b/backend/api/job_board/types.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from api.context import Info
 
 import strawberry
 
@@ -16,7 +17,7 @@ class JobListing:
     apply_url: str
 
     @strawberry.field
-    def company_logo(self, info) -> Optional[str]:
+    def company_logo(self, info: Info) -> Optional[str]:
         if not self.company_logo_url:
             return None
 

--- a/backend/api/orders/mutations.py
+++ b/backend/api/orders/mutations.py
@@ -1,6 +1,7 @@
 import re
 import typing
 from urllib.parse import urljoin
+from api.context import Info
 
 import strawberry
 from django.conf import settings
@@ -37,7 +38,7 @@ class Error:
 class OrdersMutations:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     def create_order(
-        self, info, conference: str, input: CreateOrderInput
+        self, info: Info, conference: str, input: CreateOrderInput
     ) -> typing.Union[CreateOrderResult, Error]:
         conference_obj = Conference.objects.get(code=conference)
         validation_error = validate_hotel_rooms(

--- a/backend/api/orders/query.py
+++ b/backend/api/orders/query.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from api.context import Info
 
 import strawberry
 from api.permissions import IsAuthenticated
@@ -10,7 +11,9 @@ from conferences.models import Conference
 @strawberry.type
 class OrdersQuery:
     @strawberry.field(permission_classes=[IsAuthenticated])
-    def order(self, info, conference_code: str, code: str) -> Optional[PretixOrder]:
+    def order(
+        self, info: Info, conference_code: str, code: str
+    ) -> Optional[PretixOrder]:
         conference = Conference.objects.get(code=conference_code)
 
         user = info.context.request.user

--- a/backend/api/pages/schema.py
+++ b/backend/api/pages/schema.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from api.context import Info
 
 import strawberry
 from pages.models import Page
@@ -12,9 +13,9 @@ class PagesQuery:
     # that instead of a generic argument called code
 
     @strawberry.field
-    def pages(self, info, code: str) -> List[PageType]:
+    def pages(self, info: Info, code: str) -> List[PageType]:
         return Page.published_pages.filter(conference__code=code)
 
     @strawberry.field
-    def page(self, info, code: str, slug: str) -> Optional[PageType]:
+    def page(self, info: Info, code: str, slug: str) -> Optional[PageType]:
         return Page.published_pages.by_slug(slug).filter(conference__code=code).first()

--- a/backend/api/participants/types.py
+++ b/backend/api/participants/types.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from api.context import Info
 
 import strawberry
 from strawberry import ID
@@ -26,14 +27,14 @@ class Participant:
     _previous_talk_video: strawberry.Private[str]
 
     @strawberry.field
-    def speaker_level(self, info) -> Optional[str]:
+    def speaker_level(self, info: Info) -> Optional[str]:
         if not CanSeeSubmissionPrivateFields().has_permission(self, info):
             return None
 
         return self._speaker_level
 
     @strawberry.field
-    def previous_talk_video(self, info) -> Optional[str]:
+    def previous_talk_video(self, info: Info) -> Optional[str]:
         if not CanSeeSubmissionPrivateFields().has_permission(self, info):
             return None
 

--- a/backend/api/schedule/mutations.py
+++ b/backend/api/schedule/mutations.py
@@ -1,5 +1,6 @@
 import typing
 from datetime import date, datetime, time, timedelta
+from api.context import Info
 from schedule.tasks import notify_new_schedule_invitation_answer_slack
 
 import strawberry
@@ -125,7 +126,7 @@ CancelBookingScheduleItemResult = Annotated[
 @strawberry.type
 class ScheduleMutations:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    def star_schedule_item(self, info, id: ID) -> None:
+    def star_schedule_item(self, info: Info, id: ID) -> None:
         user_id = info.context.request.user.id
 
         ScheduleItemStar.objects.update_or_create(
@@ -134,7 +135,7 @@ class ScheduleMutations:
         )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    def unstar_schedule_item(self, info, id: ID) -> None:
+    def unstar_schedule_item(self, info: Info, id: ID) -> None:
         user_id = info.context.request.user.id
         ScheduleItemStar.objects.filter(
             user_id=user_id,
@@ -142,7 +143,7 @@ class ScheduleMutations:
         ).delete()
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    def book_schedule_item(self, info, id: ID) -> BookScheduleItemResult:
+    def book_schedule_item(self, info: Info, id: ID) -> BookScheduleItemResult:
         schedule_item = ScheduleItem.objects.get(id=id)
         user_id = info.context.request.user.id
 
@@ -172,7 +173,7 @@ class ScheduleMutations:
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     def cancel_booking_schedule_item(
-        self, info, id: ID
+        self, info: Info, id: ID
     ) -> CancelBookingScheduleItemResult:
         schedule_item = ScheduleItem.objects.get(id=id)
         user_id = info.context.request.user.id
@@ -193,7 +194,7 @@ class ScheduleMutations:
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     def update_schedule_invitation(
-        self, info, input: UpdateScheduleInvitationInput
+        self, info: Info, input: UpdateScheduleInvitationInput
     ) -> typing.Union[ScheduleInvitationNotFound, ScheduleInvitation]:
         submission = Submission.objects.get_by_hashid(input.submission_id)
 
@@ -247,7 +248,7 @@ class ScheduleMutations:
 
     @strawberry.mutation(permission_classes=[IsStaffPermission])
     def add_schedule_slot(
-        self, info, conference: strawberry.ID, duration: int, day: date
+        self, info: Info, conference: strawberry.ID, duration: int, day: date
     ) -> typing.Union[AddScheduleSlotError, Day]:
         conference = Conference.objects.get(code=conference)
         day, _ = DayModel.objects.get_or_create(day=day, conference=conference)
@@ -266,7 +267,7 @@ class ScheduleMutations:
 
     @strawberry.mutation(permission_classes=[IsStaffPermission])
     def update_or_create_slot_item(
-        self, info, input: UpdateOrCreateSlotItemInput
+        self, info: Info, input: UpdateOrCreateSlotItemInput
     ) -> typing.Union[UpdateOrCreateSlotItemError, UpdateOrCreateSlotItemResult]:
         # TODO: validate this is not none
         slot = Slot.objects.select_related("day").filter(id=input.slot_id).first()

--- a/backend/api/schedule/schema.py
+++ b/backend/api/schedule/schema.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from api.context import Info
 
 import strawberry
 from strawberry import ID
@@ -15,7 +16,7 @@ from ..permissions import IsAuthenticated
 class ScheduleQuery:
     @strawberry.field(permission_classes=[IsAuthenticated])
     def schedule_invitation(
-        self, info, submission_id: ID
+        self, info: Info, submission_id: ID
     ) -> Optional[ScheduleInvitation]:
         submission = SubmissionModel.objects.get_by_hashid(submission_id)
 

--- a/backend/api/schedule/types.py
+++ b/backend/api/schedule/types.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
+from api.context import Info
 
 import strawberry
 
@@ -90,7 +91,7 @@ class ScheduleItem:
         return self.attendees_total_capacity - self.attendees.count()
 
     @strawberry.field
-    def user_has_spot(self, info) -> bool:
+    def user_has_spot(self, info: Info) -> bool:
         user_id = info.context.request.user.id
         return self.attendees.filter(user_id=user_id).exists()
 
@@ -122,18 +123,18 @@ class ScheduleItem:
         return Keynote.from_django_model(self.keynote)
 
     @strawberry.field
-    def rooms(self, info) -> List[Room]:
+    def rooms(self, info: Info) -> List[Room]:
         return self.rooms.all()
 
     @strawberry.field
-    def image(self, info) -> Optional[str]:
+    def image(self, info: Info) -> Optional[str]:
         if not self.image:
             return None
 
         return info.context.request.build_absolute_uri(self.image.url)
 
     @strawberry.field
-    def slido_url(self, info) -> str:
+    def slido_url(self, info: Info) -> str:
         if self.slido_url:
             return self.slido_url
 

--- a/backend/api/sponsors/types.py
+++ b/backend/api/sponsors/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from api.context import Info
 
 import strawberry
 from strawberry import ID
@@ -14,11 +15,11 @@ class Sponsor:
     name: str
 
     @strawberry.field
-    def link(self, info) -> str:
+    def link(self, info: Info) -> str:
         return self.link
 
     @strawberry.field
-    def image(self, info) -> str:
+    def image(self, info: Info) -> str:
         if not self.image:
             return ""
 

--- a/backend/api/submissions/schema.py
+++ b/backend/api/submissions/schema.py
@@ -1,5 +1,6 @@
 import random
 import typing
+from api.context import Info
 from api.submissions.permissions import CanSeeSubmissionRestrictedFields
 
 import strawberry
@@ -19,7 +20,7 @@ from .types import Submission, SubmissionTag
 @strawberry.type
 class SubmissionsQuery:
     @strawberry.field
-    def submission(self, info, id: strawberry.ID) -> typing.Optional[Submission]:
+    def submission(self, info: Info, id: strawberry.ID) -> typing.Optional[Submission]:
         try:
             submission = SubmissionModel.objects.get_by_hashid(id)
         except SubmissionModel.DoesNotExist:
@@ -37,7 +38,7 @@ class SubmissionsQuery:
     @strawberry.field(permission_classes=[IsAuthenticated])
     def submissions(
         self,
-        info,
+        info: Info,
         code: str,
         languages: typing.Optional[list[str]] = None,
         voted: typing.Optional[bool] = None,
@@ -120,11 +121,11 @@ class SubmissionsQuery:
         )
 
     @strawberry.field
-    def submission_tags(self, info) -> typing.List[SubmissionTag]:
+    def submission_tags(self, info: Info) -> typing.List[SubmissionTag]:
         return SubmissionTagModel.objects.order_by("name").all()
 
     @strawberry.field
-    def voting_tags(self, info, conference: str) -> typing.List[SubmissionTag]:
+    def voting_tags(self, info: Info, conference: str) -> typing.List[SubmissionTag]:
         used_tags = (
             SubmissionModel.objects.filter(
                 conference__code=conference,

--- a/backend/api/submissions/types.py
+++ b/backend/api/submissions/types.py
@@ -122,15 +122,15 @@ class Submission:
         )
 
     @strawberry.field
-    def id(self, info) -> strawberry.ID:
+    def id(self, info: Info) -> strawberry.ID:
         return self.hashid
 
     @strawberry.field
-    def can_edit(self, info) -> bool:
+    def can_edit(self, info: Info) -> bool:
         return self.can_edit(info.context.request)
 
     @strawberry.field
-    def my_vote(self, info) -> Optional[VoteType]:
+    def my_vote(self, info: Info) -> Optional[VoteType]:
         request = info.context.request
 
         if not request.user.is_authenticated:
@@ -145,11 +145,11 @@ class Submission:
             return None
 
     @strawberry.field
-    def languages(self, info) -> Optional[List[Language]]:
+    def languages(self, info: Info) -> Optional[List[Language]]:
         return self.languages.all()
 
     @strawberry.field
-    def tags(self, info) -> Optional[List[SubmissionTag]]:
+    def tags(self, info: Info) -> Optional[List[SubmissionTag]]:
         return self.tags.all()
 
 

--- a/backend/api/tests/schema/conference/test_conference.py
+++ b/backend/api/tests/schema/conference/test_conference.py
@@ -3,6 +3,7 @@ import pytz
 import time_machine
 from django.utils import timezone
 from pytest import mark
+from datetime import UTC
 
 from api.conferences.types import DeadlineStatus
 
@@ -465,8 +466,8 @@ def test_get_conference_hotel_rooms(
     graphql_client, conference_factory, bed_layout_factory, hotel_room
 ):
     hotel_room.conference = conference_factory(
-        start=timezone.datetime(2019, 1, 1, tzinfo=timezone.utc),
-        end=timezone.datetime(2019, 1, 5, tzinfo=timezone.utc),
+        start=timezone.datetime(2019, 1, 1, tzinfo=UTC),
+        end=timezone.datetime(2019, 1, 5, tzinfo=UTC),
     )
 
     bed_layout = bed_layout_factory()

--- a/backend/api/users/types.py
+++ b/backend/api/users/types.py
@@ -68,7 +68,9 @@ class User:
         )
 
     @strawberry.field
-    def starred_schedule_items(self, info, conference: str) -> List[strawberry.ID]:
+    def starred_schedule_items(
+        self, info: Info, conference: str
+    ) -> List[strawberry.ID]:
         stars = ScheduleItemStarModel.objects.filter(
             schedule_item__conference__code=conference, user_id=self.id
         ).values_list("schedule_item_id", flat=True)
@@ -85,7 +87,7 @@ class User:
         return Grant.from_model(grant) if grant else None
 
     @strawberry.field
-    def participant(self, info, conference: str) -> Optional[Participant]:
+    def participant(self, info: Info, conference: str) -> Optional[Participant]:
         participant = ParticipantModel.objects.filter(
             user_id=self.id,
             conference__code=conference,
@@ -93,7 +95,7 @@ class User:
         return Participant.from_model(participant) if participant else None
 
     @strawberry.field
-    def orders(self, info, conference: str) -> List[PretixOrder]:
+    def orders(self, info: Info, conference: str) -> List[PretixOrder]:
         conference = Conference.objects.get(code=conference)
         return sorted(
             get_user_orders(conference, self.email),
@@ -101,13 +103,15 @@ class User:
         )
 
     @strawberry.field
-    def tickets(self, info, conference: str, language: str) -> List[AttendeeTicket]:
+    def tickets(
+        self, info: Info, conference: str, language: str
+    ) -> List[AttendeeTicket]:
         conference = Conference.objects.get(code=conference)
         attendee_tickets = get_user_tickets(conference, self.email, language)
         return [ticket for ticket in attendee_tickets]
 
     @strawberry.field
-    def submissions(self, info, conference: str) -> List[Submission]:
+    def submissions(self, info: Info, conference: str) -> List[Submission]:
         return SubmissionModel.objects.filter(
             speaker_id=self.id, conference__code=conference
         )

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -1,5 +1,5 @@
 from import_export.resources import ModelResource
-from datetime import timedelta
+from datetime import timedelta, UTC
 from typing import Dict, List, Optional
 from countries.filters import CountryFilter
 from django.urls import path
@@ -191,7 +191,7 @@ def send_reply_emails(modeladmin, request, queryset):
 
             now = timezone.now()
             grant.applicant_reply_deadline = timezone.datetime(
-                now.year, now.month, now.day, 23, 59, 59
+                now.year, now.month, now.day, 23, 59, 59, tzinfo=UTC
             ) + timedelta(days=14)
             grant.save()
             send_grant_reply_approved_email.delay(grant_id=grant.id, is_reminder=False)

--- a/backend/grants/tests/test_tasks.py
+++ b/backend/grants/tests/test_tasks.py
@@ -1,11 +1,10 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from unittest.mock import patch, ANY
 from conferences.tests.factories import DeadlineFactory
 from django.test import override_settings
 
 import pytest
 from users.tests.factories import UserFactory
-from django.utils import timezone
 from pythonit_toolkit.emails.templates import EmailTemplate
 
 from grants.tests.factories import GrantFactory
@@ -86,7 +85,7 @@ def test_send_grant_reply_waiting_list_email(
     )
 
     deadline_factory(
-        start=datetime(2023, 3, 1, 23, 59, tzinfo=timezone.utc),
+        start=datetime(2023, 3, 1, 23, 59, tzinfo=UTC),
         conference=conference,
         type="custom",
         name={
@@ -116,8 +115,8 @@ def test_send_grant_reply_waiting_list_email(
 def test_handle_grant_reply_sent_reminder(conference_factory, grant_factory, settings):
     settings.FRONTEND_URL = "https://pycon.it"
     conference = conference_factory(
-        start=datetime(2023, 5, 2, tzinfo=timezone.utc),
-        end=datetime(2023, 5, 5, tzinfo=timezone.utc),
+        start=datetime(2023, 5, 2, tzinfo=UTC),
+        end=datetime(2023, 5, 5, tzinfo=UTC),
     )
     user = UserFactory(
         full_name="Marco Acierno",
@@ -128,7 +127,7 @@ def test_handle_grant_reply_sent_reminder(conference_factory, grant_factory, set
     grant = grant_factory(
         conference=conference,
         approved_type=Grant.ApprovedType.ticket_only,
-        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=UTC),
         total_amount=680,
         user=user,
     )
@@ -159,8 +158,8 @@ def test_handle_grant_approved_ticket_travel_accommodation_reply_sent(
     settings.FRONTEND_URL = "https://pycon.it"
 
     conference = conference_factory(
-        start=datetime(2023, 5, 2, tzinfo=timezone.utc),
-        end=datetime(2023, 5, 5, tzinfo=timezone.utc),
+        start=datetime(2023, 5, 2, tzinfo=UTC),
+        end=datetime(2023, 5, 5, tzinfo=UTC),
     )
     user = UserFactory(
         full_name="Marco Acierno",
@@ -172,7 +171,7 @@ def test_handle_grant_approved_ticket_travel_accommodation_reply_sent(
     grant = grant_factory(
         conference=conference,
         approved_type=Grant.ApprovedType.ticket_travel_accommodation,
-        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=UTC),
         travel_amount=680,
         user=user,
     )
@@ -204,8 +203,8 @@ def test_handle_grant_approved_ticket_travel_accommodation_fails_with_no_amount(
     settings.FRONTEND_URL = "https://pycon.it"
 
     conference = conference_factory(
-        start=datetime(2023, 5, 2, tzinfo=timezone.utc),
-        end=datetime(2023, 5, 5, tzinfo=timezone.utc),
+        start=datetime(2023, 5, 2, tzinfo=UTC),
+        end=datetime(2023, 5, 5, tzinfo=UTC),
     )
     user = UserFactory(
         full_name="Marco Acierno",
@@ -217,7 +216,7 @@ def test_handle_grant_approved_ticket_travel_accommodation_fails_with_no_amount(
     grant = grant_factory(
         conference=conference,
         approved_type=Grant.ApprovedType.ticket_travel_accommodation,
-        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=UTC),
         travel_amount=0,
         user=user,
     )
@@ -234,8 +233,8 @@ def test_handle_grant_approved_ticket_only_reply_sent(
     settings.FRONTEND_URL = "https://pycon.it"
 
     conference = conference_factory(
-        start=datetime(2023, 5, 2, tzinfo=timezone.utc),
-        end=datetime(2023, 5, 5, tzinfo=timezone.utc),
+        start=datetime(2023, 5, 2, tzinfo=UTC),
+        end=datetime(2023, 5, 5, tzinfo=UTC),
     )
     user = UserFactory(
         full_name="Marco Acierno",
@@ -247,7 +246,7 @@ def test_handle_grant_approved_ticket_only_reply_sent(
     grant = grant_factory(
         conference=conference,
         approved_type=Grant.ApprovedType.ticket_only,
-        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=UTC),
         total_amount=680,
         user=user,
     )
@@ -278,8 +277,8 @@ def test_handle_grant_approved_travel_reply_sent(
     settings.FRONTEND_URL = "https://pycon.it"
 
     conference = conference_factory(
-        start=datetime(2023, 5, 2, tzinfo=timezone.utc),
-        end=datetime(2023, 5, 5, tzinfo=timezone.utc),
+        start=datetime(2023, 5, 2, tzinfo=UTC),
+        end=datetime(2023, 5, 5, tzinfo=UTC),
     )
     user = UserFactory(
         full_name="Marco Acierno",
@@ -291,7 +290,7 @@ def test_handle_grant_approved_travel_reply_sent(
     grant = grant_factory(
         conference=conference,
         approved_type=Grant.ApprovedType.ticket_travel,
-        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+        applicant_reply_deadline=datetime(2023, 2, 1, 23, 59, tzinfo=UTC),
         total_amount=680,
         user=user,
     )
@@ -320,7 +319,7 @@ def test_send_grant_reply_waiting_list_update_email(sent_emails):
     grant = GrantFactory()
     DeadlineFactory(
         conference=grant.conference,
-        start=datetime(2023, 3, 1, 23, 59, tzinfo=timezone.utc),
+        start=datetime(2023, 3, 1, 23, 59, tzinfo=UTC),
         type="custom",
         name={
             "en": "Update Grants in Waiting List",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ x-defaults:
     <<: *enviroment_defaults
     CACHE_URL: redis://redis:6379/0
     DATABASE_URL: psql://pycon:pycon@pycon-backend-db/pycon
-    DJANGO_SETTINGS_MODULE: pycon.settings.dev
     ALLOWED_HOSTS: "*"
     PRETIX_API_TOKEN: ${PRETIX_API_TOKEN}
     MAILCHIMP_SECRET_KEY: ${MAILCHIMP_SECRET_KEY}
@@ -54,7 +53,7 @@ services:
       pdm run python manage.py migrate &&
       pdm run python manage.py create_admin &&
       touch /.ready &&
-      pdm run python manage.py runserver 0.0.0.0:8000"
+      DJANGO_SETTINGS_MODULE=pycon.settings.dev pdm run python manage.py runserver 0.0.0.0:8000"
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
Left to fix:

- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/wagtail/admin/staticfiles.py:26: RemovedInDjango51Warning: django.core.files.storage.get_storage_class is deprecated in favor of using django.core.files.storage.storages.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/django/conf/__init__.py:201: RemovedInDjango51Warning: The STATICFILES_STORAGE setting is deprecated. Use STORAGES instead.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/model_utils/__init__.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'taggit.TaggedItem' instead.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/strawberry/types/fields/resolver.py:229: DeprecationWarning: Argument name-based matching of 'info' is deprecated and will be removed in v1.0. Ensure that reserved arguments are annotated their respective types (i.e. use value: 'DirectiveValue[str]' instead of 'value: str' and 'info: Info' instead of a plain 'info').
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/xdist/plugin.py:252: DeprecationWarning: The --rsyncdir command line argument and rsyncdirs config variable are deprecated.  The rsync feature will be removed in pytest-xdist 4.0.    config.issue_config_time_warning(warning, 2)
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/l18n/translation.py:17: DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/factory/django.py:181: DeprecationWarning: UserFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/whitenoise/base.py:115: UserWarning: No directory at: /home/runner/work/pycon/pycon/backend/static/
- [ ]   /home/runner/work/pycon/pycon/backend/api/cms/page/blocks/slider_cards_section.py:44: DeprecationWarning: Passing types to `strawberry.union` is deprecated. Please use AvailableCards = Annotated[Union[A, B], strawberry.union("AvailableCards")] instead
- [ ]   /home/runner/work/pycon/pycon/backend/api/cms/page/types.py:44: DeprecationWarning: Passing types to `strawberry.union` is deprecated. Please use Block = Annotated[Union[A, B], strawberry.union("Block")] instead
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Page.first_published_at received a naive datetime (2010-01-01 10:00:00) while time zone support is active.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Page.first_published_at received a naive datetime (2012-01-01 10:00:00) while time zone support is active.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/factory/django.py:181: DeprecationWarning: ConferenceFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/factory/django.py:181: DeprecationWarning: SubmissionFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/factory/django.py:181: DeprecationWarning: ScheduleItemFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/factory/django.py:181: DeprecationWarning: RankRequestFactory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release.
- [ ]   /home/runner/work/pycon/pycon/backend/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Keynote.published received a naive datetime (1995-12-01 05:10:03) while time zone support is active.
- [ ]   /home/runner/work/pycon/pycon/backend/schedule/tests/test_tasks.py:217: RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.