### PR TITLE
Add filters in the Review recap screens for Grants

### DIFF
--- a/backend/reviews/admin.py
+++ b/backend/reviews/admin.py
@@ -360,11 +360,12 @@ class ReviewSessionAdmin(ConferencePermissionMixin, admin.ModelAdmin):
             proposals=proposals,
             review_session_id=review_session_id,
             review_session_repr=str(review_session),
-            all_statuses=[
+            all_review_statuses=[
                 choice
                 for choice in Grant.Status.choices
                 if choice[0] in Grant.REVIEW_SESSION_STATUSES_OPTIONS
             ],
+            all_statuses=Grant.Status.choices,
             all_approved_types=[choice for choice in Grant.ApprovedType.choices],
             review_session=review_session,
             title="Recap",

--- a/backend/reviews/templates/grants-recap.html
+++ b/backend/reviews/templates/grants-recap.html
@@ -1,676 +1,696 @@
-{% extends "admin/base_site.html" %}
-{% load i18n %}
-{% load markdownify %}
-{% load localize countryname get_item %}
-{% block breadcrumbs %}
-    <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-        &rsaquo; <a href="{% url 'admin:app_list' 'reviews' %}">Reviews</a>
-        &rsaquo; <a href="{% url 'admin:reviews_reviewsession_changelist' %}">Review sessions</a>
-        &rsaquo; <a href="{% url 'admin:reviews_reviewsession_change' review_session_id %}">{{ review_session_repr }}</a>
-        &rsaquo; {{ title }}
-    </div>
-{% endblock %}
-{% block content %}
-    <style>
-        * {
-            box-sizing: border-box;
-        }
+{% extends "admin/base_site.html" %} {% load i18n %} {% load markdownify %}
+{% load localize countryname get_item %} {% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' 'reviews' %}">Reviews</a> &rsaquo;
+  <a href="{% url 'admin:reviews_reviewsession_changelist' %}"
+    >Review sessions</a
+  >
+  &rsaquo;
+  <a href="{% url 'admin:reviews_reviewsession_change' review_session_id %}"
+    >{{ review_session_repr }}</a
+  >
+  &rsaquo; {{ title }}
+</div>
+{% endblock %} {% block content %}
+<style>
+  * {
+    box-sizing: border-box;
+  }
 
-        .status-choices {
-            width: 150px;
-        }
+  .status-choices {
+    width: 150px;
+  }
 
-        .approved-type-choices {
-            width: 200px;
-        }
+  .approved-type-choices {
+    width: 200px;
+  }
 
-        .status-choices,
-        .approved-type-choices {
-            list-style: none;
-        }
+  .status-choices,
+  .approved-type-choices {
+    list-style: none;
+  }
 
-        .status-choices li,
-        .approved-type-choices li {
-            list-style: none;
-        }
+  .status-choices li,
+  .approved-type-choices li {
+    list-style: none;
+  }
 
-        .needs-list {
-            display: inline-block;
-            margin-top: 0;
-        }
+  .needs-list {
+    display: inline-block;
+    margin-top: 0;
+  }
 
-        .needs-list li {
-            display: inline-block;
-        }
+  .needs-list li {
+    display: inline-block;
+  }
 
-        .needs-list li::after {
-            content: ',';
-        }
+  .needs-list li::after {
+    content: ",";
+  }
 
-        .needs-list li:last-child:after {
-            display: none;
-        }
+  .needs-list li:last-child:after {
+    display: none;
+  }
 
-        .results-table {
-            width: 100%;
-        }
+  .results-table {
+    width: 100%;
+  }
 
-        .decision-input-wrapper label {
-            display: block;
-        }
+  .decision-input-wrapper label {
+    display: block;
+  }
 
-        .decision-input-wrapper input {
-            width: 20px;
-            height: 20px;
-            margin-right: 5px;
-        }
+  .decision-input-wrapper input {
+    width: 20px;
+    height: 20px;
+    margin-right: 5px;
+  }
 
-        .reviews-bottom-bar {
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            z-index: 500;
-            background-color: #417690;
-            color: #fff;
-        }
+  .reviews-bottom-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 500;
+    background-color: #417690;
+    color: #fff;
+  }
 
-        .reviews-bottom-bar-content {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-        }
+  .reviews-bottom-bar-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
-        .reviews-bottom-bar-stats {
-            display: flex;
-            align-items: center;
-            justify-content: flex-end;
-            gap: 50px;
-        }
+  .reviews-bottom-bar-stats {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 50px;
+  }
 
-        .reviews-bottom-bar-stats tr{
-          background-color: #417690;
-        }
-        .reviews-bottom-bar-stats td{
-          border-bottom: 0;
-        }
+  .reviews-bottom-bar-stats tr {
+    background-color: #417690;
+  }
+  .reviews-bottom-bar-stats td {
+    border-bottom: 0;
+  }
 
-        .reviews-bottom-bar-confirm-bar {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 10px;
-            max-width: 800px;
-        }
+  .reviews-bottom-bar-confirm-bar {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    max-width: 800px;
+  }
 
-        .results-table ul {
-            margin-left: 0;
-            padding: 0;
-            list-style-type: none;
-            list-style-position: inside;
-        }
+  .results-table ul {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+    list-style-position: inside;
+  }
 
-        .results-table .votes-list {
-            max-width: 800px;
-        }
+  .results-table .votes-list {
+    max-width: 800px;
+  }
 
-        .results-item ul li {
-            list-style: none;
-        }
+  .results-item ul li {
+    list-style: none;
+  }
 
-        table.results-table {
-            border-collapse: separate;
-            border-spacing: 0;
-        }
+  table.results-table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
 
-        .results-table thead {
-            position: sticky;
-            top: 43px;
-        }
+  .results-table thead {
+    position: sticky;
+    top: 43px;
+  }
 
-        .hidden {
-            display: none;
-        }
+  .hidden {
+    display: none;
+  }
 
-        .pending-grants-num span {
-          color: #48ff5a;
-        }
+  .pending-grants-num span {
+    color: #48ff5a;
+  }
 
-        .current-grants-num span {
-          color: #FFA500;
-        }
+  .current-grants-num span {
+    color: #ffa500;
+  }
 
-        .grant-proposal-ranking {
-            display: inline;
-        }
+  .grant-proposal-ranking {
+    display: inline;
+  }
 
-        .grant-proposal-ranking li {
-            display: inline;
-        }
+  .grant-proposal-ranking li {
+    display: inline;
+  }
 
-        .grant-proposal-ranking li:after {
-            content: ',';
-        }
+  .grant-proposal-ranking li:after {
+    content: ",";
+  }
 
-        .grant-proposal-ranking li:last-child:after {
-            display: none;
-        }
+  .grant-proposal-ranking li:last-child:after {
+    display: none;
+  }
 
-        ul.proposals-ranking {
-            margin-left: 30px;
-        }
+  ul.proposals-ranking {
+    margin-left: 30px;
+  }
 
-        ul.proposals-ranking li {
-            list-style: square;
-        }
+  ul.proposals-ranking li {
+    list-style: square;
+  }
 
-        .opt-filter {
-          display: grid;
-          gap: 10px;
-          grid-template-columns: max-content auto;
-          align-items: center;
-          margin-top: 10px;
-        }
+  .opt-filter {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: max-content auto;
+    align-items: center;
+    margin-top: 10px;
+  }
 
-        .opt-filter label + label {
-          margin-left: 10px;
-        }
+  .opt-filter label + label {
+    margin-left: 10px;
+  }
+</style>
+<script type="application/javascript">
+  const grantsById = {};
+  let grants;
 
-    </style>
-    <script type="application/javascript">
-        const grantsById = {};
-        let grants;
+  const pendingStatusNumRef = {}
+  const currentStatusNumRef = {}
 
-        const pendingStatusNumRef = {}
-        const currentStatusNumRef = {}
+  const getRefs = () => {
+    {% for status in all_review_statuses %}
+    pendingStatusNumRef["{{status.0}}"] = document.querySelector("#pending-{{status.0}}-grants-num");
+    {% endfor %}
 
-        const getRefs = () => {
-          {% for status in all_review_statuses %}
-          pendingStatusNumRef["{{status.0}}"] = document.querySelector("#pending-{{status.0}}-grants-num");
-          {% endfor %}
+    {% for status in all_statuses %}
+      currentStatusNumRef["{{status.0}}"] = document.querySelector("#current-{{status.0}}-grants-num");
+    {% endfor %}
 
-          {% for status in all_statuses %}
-            currentStatusNumRef["{{status.0}}"] = document.querySelector("#current-{{status.0}}-grants-num");
-          {% endfor %}
+    const acc = {
+      {% for status in all_statuses %}
+      "{{status.0}}": 0,
+      {% endfor %}
+    };
 
-          const acc = {
-            {% for status in all_statuses %}
-            "{{status.0}}": 0,
-            {% endfor %}
-          };
+    grants.forEach(grant => {
+      acc[grant.originalStatus]++;
+    });
 
-          grants.forEach(grant => {
-            acc[grant.originalStatus]++;
+    {% for status in all_statuses %}
+      currentStatusNumRef["{{status.0}}"].innerText = acc["{{status.0}}"];
+    {% endfor %}
+  };
+
+
+
+  window.addEventListener("load", () => {
+      grants = Object.values(grantsById);
+
+      getRefs();
+      updateBottomBarUI();
+
+      grants.forEach((grantData) => {
+          const grantId = grantData.id;
+          const approvedInput = document.getElementById(
+              `decision-${grantId}-approved`,
+          );
+          const rejectInput = document.getElementById(
+              `decision-${grantId}-rejected`,
+          );
+          const unsetInput = document.getElementById(
+              `decision-${grantId}-unset`,
+          );
+          const waitinglistInput = document.getElementById(
+              `decision-${grantId}-waiting_list`,
+          );
+          const waitinglistmaybeInput = document.getElementById(
+              `decision-${grantId}-waiting_list_maybe`,
+          );
+
+          approvedInput.addEventListener("change", () => {
+              grantData.status = "approved";
+              updateBottomBarUI();
           });
 
+          rejectInput.addEventListener("change", () => {
+              grantData.status = "rejected";
+              updateBottomBarUI();
+          });
+
+          waitinglistInput.addEventListener("change", () => {
+              grantData.status = "waiting_list";
+              updateBottomBarUI();
+          });
+
+          waitinglistInput.addEventListener("change", () => {
+              grantData.status = "waiting_list_maybe";
+              updateBottomBarUI();
+          });
+
+          unsetInput.addEventListener("change", () => {
+              const proposalRow = document.querySelector(`#grant-${grantId}`);
+              const originalStatus = proposalRow.dataset.originalStatus;
+
+              if (originalStatus === "approved") {
+                  approvedInput.checked = true;
+              } else if (originalStatus === "rejected") {
+                  rejectInput.checked = true;
+              } else if (originalStatus === "waiting_list") {
+                  waitinglistInput.checked = true;
+              } else if (originalStatus === "waiting_list_maybe") {
+                  waitinglistmaybeInput.checked = true;
+              }
+
+              unsetInput.checked = false;
+              grantData.status = originalStatus;
+              updateBottomBarUI();
+          });
+      });
+  });
+
+  window.onload = () => {
+      document.querySelectorAll('.unset-radio').forEach(radio => {
+          radio.addEventListener('click', () => {
+              radio.checked = false;
+
+              const grantId = radio.name.split('-')[1];
+              const grantRow = document.querySelector(`#grant-${grantId}`);
+
+              const originalStatus = grantRow.dataset.originalStatus;
+              const originalApprovedType = grantRow.dataset.originalApprovedType;
+
+              grantRow.querySelector(`.status-decision-radio[value="${originalStatus}"]`).checked = true;
+
+              if (originalApprovedType !== 'None') {
+                  grantRow.querySelector(`.approved-type-choices input[value="${originalApprovedType}"]`).checked = true;
+              }
+
+              if (originalStatus === "approved") {
+                  grantRow.querySelector(`.approved-type-choices`).classList.remove('hidden');
+              } else {
+                  grantRow.querySelector(`.approved-type-choices`).classList.add('hidden');
+              }
+          });
+      });
+
+      document.querySelectorAll('.status-decision-radio').forEach(radio => {
+          radio.addEventListener('click', () => {
+              const grantId = radio.name.split('-')[1];
+
+              const approvedTypeSection = document.querySelector(`.approved-type-choices[data-item-id="${grantId}"]`)
+
+              if (radio.value === "approved") {
+                  approvedTypeSection.classList.remove('hidden');
+              } else {
+                  approvedTypeSection.classList.add('hidden');
+              }
+          });
+      });
+
+      const filterByStatusInputs = [...document.querySelectorAll('input[name="filter-by-status"]')];
+      filterByStatusInputs.forEach(
+          filterByStatusInput => {
+              filterByStatusInput.addEventListener('change', e => {
+                  e.preventDefault();
+
+                  const filterValue = e.target.value;
+                  const visibleStatuses = filterByStatusInputs.filter(
+                      input => input.checked
+                  ).map(
+                      input => input.value
+                  );
+
+                  document.querySelectorAll('.grant-item').forEach(
+                      grantRow => {
+                          const grantId = parseInt(grantRow.id.split('-')[1], 10);
+                          const grantData = grantsById[grantId];
+
+                          if (visibleStatuses.includes(grantData.originalStatus)) {
+                              grantRow.classList.remove('hidden')
+                          } else {
+                              grantRow.classList.add('hidden')
+                          }
+                      }
+                  );
+              });
+          }
+      );
+
+
+
+  };
+
+  const updateBottomBarUI = () => {
+      const   acc = {}
+      {% for status in all_review_statuses %}
+        acc["{{status.0}}"] = 0
+      {% endfor %}
+
+      const results = grants.reduce(
+          (acc, grant) => {
+            const grantStatus = grant.status;
+            acc[grantStatus]++;
+            return acc
+          },
+          acc,
+      );
+
+      {% for status in all_review_statuses %}
+        pendingStatusNumRef["{{status.0}}"].innerText = results["{{status.0}}"];
+      {% endfor %}
+
+  };
+</script>
+<ul class="object-tools">
+  <li>
+    <a
+      target="_blank"
+      href="{% url 'admin:grants-summary' %}?conference__id__exact={{ review_session.conference_id }}"
+      class="change-list-object-tools-item"
+      >Open Grants Summary</a
+    >
+  </li>
+</ul>
+<form id="changelist-form" method="post" novalidate="">
+  {% csrf_token %}
+  <div id="content-main">
+    <div class="module filtered">
+      <h2>Filters</h2>
+      <div class="opt-filter">
+        <h3>
+          Show grants with
+          <strong style="text-transform: uppercase">current</strong> status:
+        </h3>
+        <div>
           {% for status in all_statuses %}
-            currentStatusNumRef["{{status.0}}"].innerText = acc["{{status.0}}"];
+          <label>
+            <input
+              checked
+              type="checkbox"
+              name="filter-by-status"
+              value="{{ status.0 }}"
+            />
+            <span>{{ status.1 }}</span>
+          </label>
           {% endfor %}
-        };
-
-
-
-        window.addEventListener("load", () => {
-            grants = Object.values(grantsById);
-
-            getRefs();
-            updateBottomBarUI();
-
-            grants.forEach((grantData) => {
-                const grantId = grantData.id;
-                const approvedInput = document.getElementById(
-                    `decision-${grantId}-approved`,
-                );
-                const rejectInput = document.getElementById(
-                    `decision-${grantId}-rejected`,
-                );
-                const unsetInput = document.getElementById(
-                    `decision-${grantId}-unset`,
-                );
-                const waitinglistInput = document.getElementById(
-                    `decision-${grantId}-waiting_list`,
-                );
-                const waitinglistmaybeInput = document.getElementById(
-                    `decision-${grantId}-waiting_list_maybe`,
-                );
-
-                approvedInput.addEventListener("change", () => {
-                    grantData.status = "approved";
-                    updateBottomBarUI();
-                });
-
-                rejectInput.addEventListener("change", () => {
-                    grantData.status = "rejected";
-                    updateBottomBarUI();
-                });
-
-                waitinglistInput.addEventListener("change", () => {
-                    grantData.status = "waiting_list";
-                    updateBottomBarUI();
-                });
-
-                waitinglistInput.addEventListener("change", () => {
-                    grantData.status = "waiting_list_maybe";
-                    updateBottomBarUI();
-                });
-
-                unsetInput.addEventListener("change", () => {
-                    const proposalRow = document.querySelector(`#grant-${grantId}`);
-                    const originalStatus = proposalRow.dataset.originalStatus;
-
-                    if (originalStatus === "approved") {
-                        approvedInput.checked = true;
-                    } else if (originalStatus === "rejected") {
-                        rejectInput.checked = true;
-                    } else if (originalStatus === "waiting_list") {
-                        waitinglistInput.checked = true;
-                    } else if (originalStatus === "waiting_list_maybe") {
-                        waitinglistmaybeInput.checked = true;
-                    }
-
-                    unsetInput.checked = false;
-                    grantData.status = originalStatus;
-                    updateBottomBarUI();
-                });
-            });
-        });
-
-        window.onload = () => {
-            document.querySelectorAll('.unset-radio').forEach(radio => {
-                radio.addEventListener('click', () => {
-                    radio.checked = false;
-
-                    const grantId = radio.name.split('-')[1];
-                    const grantRow = document.querySelector(`#grant-${grantId}`);
-
-                    const originalStatus = grantRow.dataset.originalStatus;
-                    const originalApprovedType = grantRow.dataset.originalApprovedType;
-
-                    grantRow.querySelector(`.status-decision-radio[value="${originalStatus}"]`).checked = true;
-
-                    if (originalApprovedType !== 'None') {
-                        grantRow.querySelector(`.approved-type-choices input[value="${originalApprovedType}"]`).checked = true;
-                    }
-
-                    if (originalStatus === "approved") {
-                        grantRow.querySelector(`.approved-type-choices`).classList.remove('hidden');
-                    } else {
-                        grantRow.querySelector(`.approved-type-choices`).classList.add('hidden');
-                    }
-                });
-            });
-
-            document.querySelectorAll('.status-decision-radio').forEach(radio => {
-                radio.addEventListener('click', () => {
-                    const grantId = radio.name.split('-')[1];
-
-                    const approvedTypeSection = document.querySelector(`.approved-type-choices[data-item-id="${grantId}"]`)
-
-                    if (radio.value === "approved") {
-                        approvedTypeSection.classList.remove('hidden');
-                    } else {
-                        approvedTypeSection.classList.add('hidden');
-                    }
-                });
-            });
-
-            const filterByStatusInputs = [...document.querySelectorAll('input[name="filter-by-status"]')];
-            filterByStatusInputs.forEach(
-                filterByStatusInput => {
-                    filterByStatusInput.addEventListener('change', e => {
-                        e.preventDefault();
-
-                        const filterValue = e.target.value;
-                        const visibleStatuses = filterByStatusInputs.filter(
-                            input => input.checked
-                        ).map(
-                            input => input.value
-                        );
-
-                        document.querySelectorAll('.grant-item').forEach(
-                            grantRow => {
-                                const grantId = parseInt(grantRow.id.split('-')[1], 10);
-                                const grantData = grantsById[grantId];
-
-                                if (visibleStatuses.includes(grantData.originalStatus)) {
-                                    grantRow.classList.remove('hidden')
-                                } else {
-                                    grantRow.classList.add('hidden')
-                                }
-                            }
-                        );
-                    });
-                }
-            );
-
-
-
-        };
-
-        const updateBottomBarUI = () => {
-            const   acc = {}
-            {% for status in all_review_statuses %}
-              acc["{{status.0}}"] = 0
-            {% endfor %}
-
-            const results = grants.reduce(
-                (acc, grant) => {
-                  const grantStatus = grant.status;
-                  acc[grantStatus]++;
-                  return acc
-                },
-                acc,
-            );
-
-            {% for status in all_review_statuses %}
-              pendingStatusNumRef["{{status.0}}"].innerText = results["{{status.0}}"];
-            {% endfor %}
-
-        };
-    </script>
-    <ul class="object-tools">
-        <li>
-            <a target="_blank"
-               href="{% url 'admin:grants-summary' %}?conference__id__exact={{ review_session.conference_id }}"
-               class="change-list-object-tools-item">Open Grants Summary</a>
-        </li>
-    </ul>
-    <form id="changelist-form" method="post" novalidate="">
-        {% csrf_token %}
-        <div id="content-main">
-            <div class="module filtered">
-                <h2>Filters</h2>
-                <div class="opt-filter">
-                    <h3>Show grants with <strong style="text-transform: uppercase">current</strong> status:</h3>
-                    <div>
-                        {% for status in all_statuses %}
-                            <label>
-                                <input checked
-                                       type="checkbox"
-                                       name="filter-by-status"
-                                       value="{{ status.0 }}">
-                                <span>{{ status.1 }}</span>
-                            </label>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-            <div class="module filtered" id="changelist">
-                <div class="changelist-form-container">
-                    <div class="results">
-                        <table id="result_list" class="results-table">
-                            <thead>
-                                <tr>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>#</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>Grant</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <a>Score</a>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>Votes</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>Current Status</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>Decision</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                    <th scope="col">
-                                        <div class="text">
-                                            <span>Approved type</span>
-                                        </div>
-                                        <div class="clear"></div>
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for item in items %}
-                                    <script>
-                                        grantsById[{{item.id}}] = {
-                                            id: {{item.id}},
-                                            status: "{{ item.status }}",
-                                            originalStatus: "{{ item.status }}",
-                                            numOfVotes: {{item.userreview_set.count}},
-                                        };
-                                    </script>
-                                    <tr data-original-status="{{ item.status }}"
-                                        data-original-approved-type="{{ item.approved_type }}"
-                                        class="grant-item"
-                                        id="grant-{{ item.id }}"
-                                        data-type="{{ item.type }}"
-                                        data-num-of-votes="{{ item.userreview_set.count }}">
-                                        <td>{{ forloop.counter }}</td>
-                                        <td class="results-item">
-                                            <a target="_blank" href="{% url 'admin:grants_grant_change' item.id %}">
-                                                <strong>{{ item.name }} - {{ item.full_name }}</strong>
-                                            </a>
-                                            <ul>
-                                                <li>
-                                                    <strong>Gender:</strong>
-                                                    <span>{{ item.get_gender_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Age Group:</strong>
-                                                    <span>{{ item.get_age_group_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Occupation:</strong>
-                                                    <span>{{ item.get_occupation_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Travelling From:</strong>
-                                                    <span>{{ item.get_travelling_from_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Country type:</strong>
-                                                    <span>{{ item.get_country_type_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Grant type:</strong>
-                                                    <span>{{ item.get_grant_type_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Needs:</strong>
-                                                    <ul class="needs-list">
-                                                        {% if item.need_visa %}<li>VISA</li>{% endif %}
-                                                        {% if item.need_accommodation %}<li>Accommodation</li>{% endif %}
-                                                        {% if item.needs_funds_for_travel %}<li>Funds for Travel</li>{% endif %}
-                                                        {% if not item.need_visa and not item.need_accommodation and not item.needs_funds_for_travel %}
-                                                            <li>Ticket only</li>
-                                                        {% endif %}
-                                                    </ul>
-                                                </li>
-                                                <li>
-                                                    <strong>Interested in Volunteering?</strong>
-                                                    <span>{{ item.get_interested_in_volunteering_display }}</span>
-                                                </li>
-                                                <li>
-                                                    <strong>Has sent a proposal?</strong>
-                                                    <span>{{ item.has_sent_a_proposal|yesno }}</span>
-                                                </li>
-                                                {% if item.has_sent_a_proposal %}
-                                                    <li>
-                                                        <strong>Proposals Ranking:</strong>
-                                                        <ul class="proposals-ranking">
-                                                            {% for proposal_id in item.proposals_ids %}
-                                                                {% with proposal=proposals|get_item:proposal_id %}
-                                                                    <li>
-                                                                        <strong><a target="_blank"
-   href="{% url 'admin:submissions_submission_change' proposal.id %}">{{ proposal.title }}:</a></strong>
-                                                                        <ul class="grant-proposal-ranking">
-                                                                            {% for ranking in proposal.rankings.all %}
-                                                                                <li>{{ ranking.tag.name }} {{ ranking.rank }}/{{ ranking.total_submissions_per_tag }}</li>
-                                                                            {% endfor %}
-                                                                        </ul>
-                                                                    </li>
-                                                                {% endwith %}
-                                                            {% endfor %}
-                                                        </ul>
-                                                    </li>
-                                                {% endif %}
-                                            </ul>
-                                        </td>
-                                        <td>{{ item.score }}</td>
-                                        <td class="votes-list">
-                                            <ul>
-                                                {% for reviewer in item.userreview_set.all %}
-                                                    <li>
-                                                        <strong>{{ reviewer.user.full_name }}</strong> voted
-                                                        {{ reviewer.score.label }}
-                                                        ({{ reviewer.score.numeric_value }})
-                                                        <br />
-                                                        {{ reviewer.comment }}
-                                                    </li>
-                                                {% empty %}
-                                                    <li>No reviews yet</li>
-                                                {% endfor %}
-                                                <li>
-                                                    <a style="font-weight: bold"
-                                                       target="_blank"
-                                                       href="{% url 'admin:reviews-vote-view' review_session_id=review_session_id review_item_id=item.id %}">
-                                                        Open Grant review screen
-                                                    </a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                        <td>
-                                            {{ item.get_status_display }}
-                                            <br />
-                                            {% if item.approved_type %}({{ item.get_approved_type_display }}){% endif %}
-                                        </td>
-                                        <td>
-                                            {% if perms.reviews.decision_reviewsession %}
-                                                <ul class="status-choices">
-                                                    {% for status in all_review_statuses %}
-                                                        <li>
-                                                            <label>
-                                                                <input {% if item.status == status.0 %}checked{% endif %}
-                                                                       type="radio"
-                                                                       class="status-decision-radio"
-                                                                       name="decision-{{ item.id }}"
-                                                                       id="decision-{{ item.id }}-{{ status.0 }}"
-                                                                       value="{{ status.0 }}" />
-                                                                {{ status.1 }}
-                                                            </label>
-                                                        </li>
-                                                    {% endfor %}
-                                                    <li>
-                                                        <label>
-                                                            <input class="unset-radio"
-                                                                   type="radio"
-                                                                   name="decision-{{ item.id }}"
-                                                                   id="decision-{{ item.id }}-unset"
-                                                                   value="unset" />
-                                                            Unset
-                                                        </label>
-                                                    </li>
-                                                </ul>
-                                            {% else %}
-                                                No permission to change.
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            {% if perms.reviews.decision_reviewsession %}
-                                                <ul data-item-id="{{ item.id }}"
-                                                    class="approved-type-choices {% if item.status != 'approved' %}hidden{% endif %}">
-                                                    {% for approved_type in all_approved_types %}
-                                                        <li>
-                                                            <label>
-                                                                <input {% if item.approved_type == approved_type.0 %}checked{% endif %}
-                                                                       type="radio"
-                                                                       name="approvedtype-{{ item.id }}"
-                                                                       value="{{ approved_type.0 }}" />
-                                                                {{ approved_type.1 }}
-                                                            </label>
-                                                        </li>
-                                                    {% endfor %}
-                                                    <li>
-                                                        <label>
-                                                            <input class="unset-radio"
-                                                                   type="radio"
-                                                                   name="approvedtype-{{ item.id }}"
-                                                                   value="unset" />
-                                                            Unset
-                                                        </label>
-                                                    </li>
-                                                </ul>
-                                            {% else %}
-                                                No permission to change.
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-            <div style="height: 100px"></div>
         </div>
-        {% if perms.reviews.decision_reviewsession %}
-            <div id="content" class="reviews-bottom-bar colM">
-                <div class="reviews-bottom-bar-content">
-                    <div class="submit-row reviews-bottom-bar-confirm-bar">
-                        <p>
-                            Once done, click the button to save your choices.
-                            You can change as many times as you need, no emails will be sent.
-                        </p>
-                        <input value="Submit choices" type="submit" />
-                    </div>
-                    <div class="reviews-bottom-bar-stats">
-                        <table>
-                            <tbody>
-                              <tr>
-                                <td><h2>Pending status ➡ </h2></td>
-                                {% for status in all_statuses %}
-                                <td>
-                                  {% if status in all_review_statuses %}
-                                    <h2 class="pending-grants-num">
-                                        {{status.1}}: <span id="pending-{{status.0}}-grants-num">0</span>
-                                    </h2>
-                                    {% endif %}
-                                </td>
-                                {% endfor %}
-                              </tr>
-                              <tr>
-                                <td><h2>Current status ➡ </h2></td>
-                                {% for status in all_statuses %}
-                                <td>
-                                    <h2 class="current-grants-num" >
-                                        {{status.1}}: <span id="current-{{status.0}}-grants-num">0</span>
-                                    </h2>
-                                </td>
-                                {% endfor %}
-                              </tr>
-
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-    </form>
+      </div>
+    </div>
+    <div class="module filtered" id="changelist">
+      <div class="changelist-form-container">
+        <div class="results">
+          <table id="result_list" class="results-table">
+            <thead>
+              <tr>
+                <th scope="col">
+                  <div class="text">
+                    <span>#</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <span>Grant</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <a>Score</a>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <span>Votes</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <span>Current Status</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <span>Decision</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+                <th scope="col">
+                  <div class="text">
+                    <span>Approved type</span>
+                  </div>
+                  <div class="clear"></div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in items %}
+              <script>
+                grantsById[{{item.id}}] = {
+                    id: {{item.id}},
+                    status: "{{ item.status }}",
+                    originalStatus: "{{ item.status }}",
+                    numOfVotes: {{item.userreview_set.count}},
+                };
+              </script>
+              <tr
+                data-original-status="{{ item.status }}"
+                data-original-approved-type="{{ item.approved_type }}"
+                class="grant-item"
+                id="grant-{{ item.id }}"
+                data-type="{{ item.type }}"
+                data-num-of-votes="{{ item.userreview_set.count }}"
+              >
+                <td>{{ forloop.counter }}</td>
+                <td class="results-item">
+                  <a
+                    target="_blank"
+                    href="{% url 'admin:grants_grant_change' item.id %}"
+                  >
+                    <strong>{{ item.name }} - {{ item.full_name }}</strong>
+                  </a>
+                  <ul>
+                    <li>
+                      <strong>Gender:</strong>
+                      <span>{{ item.get_gender_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Age Group:</strong>
+                      <span>{{ item.get_age_group_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Occupation:</strong>
+                      <span>{{ item.get_occupation_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Travelling From:</strong>
+                      <span>{{ item.get_travelling_from_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Country type:</strong>
+                      <span>{{ item.get_country_type_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Grant type:</strong>
+                      <span>{{ item.get_grant_type_display }}</span>
+                    </li>
+                    <li>
+                      <strong>Needs:</strong>
+                      <ul class="needs-list">
+                        {% if item.need_visa %}
+                        <li>VISA</li>
+                        {% endif %} {% if item.need_accommodation %}
+                        <li>Accommodation</li>
+                        {% endif %} {% if item.needs_funds_for_travel %}
+                        <li>Funds for Travel</li>
+                        {% endif %} {% if not item.need_visa and not item.need_accommodation and not item.needs_funds_for_travel %}
+                        <li>Ticket only</li>
+                        {% endif %}
+                      </ul>
+                    </li>
+                    <li>
+                      <strong>Interested in Volunteering?</strong>
+                      <span
+                        >{{ item.get_interested_in_volunteering_display }}</span
+                      >
+                    </li>
+                    <li>
+                      <strong>Has sent a proposal?</strong>
+                      <span>{{ item.has_sent_a_proposal|yesno }}</span>
+                    </li>
+                    {% if item.has_sent_a_proposal %}
+                    <li>
+                      <strong>Proposals Ranking:</strong>
+                      <ul class="proposals-ranking">
+                        {% for proposal_id in item.proposals_ids %} {% with proposal=proposals|get_item:proposal_id %}
+                        <li>
+                          <strong
+                            ><a
+                              target="_blank"
+                              href="{% url 'admin:submissions_submission_change' proposal.id %}"
+                              >{{ proposal.title }}:</a
+                            ></strong
+                          >
+                          <ul class="grant-proposal-ranking">
+                            {% for ranking in proposal.rankings.all %}
+                            <li>
+                              {{ ranking.tag.name }} {{ ranking.rank }}/{{ ranking.total_submissions_per_tag }}
+                            </li>
+                            {% endfor %}
+                          </ul>
+                        </li>
+                        {% endwith %} {% endfor %}
+                      </ul>
+                    </li>
+                    {% endif %}
+                  </ul>
+                </td>
+                <td>{{ item.score }}</td>
+                <td class="votes-list">
+                  <ul>
+                    {% for reviewer in item.userreview_set.all %}
+                    <li>
+                      <strong>{{ reviewer.user.full_name }}</strong> voted
+                      {{ reviewer.score.label }} ({{ reviewer.score.numeric_value }})
+                      <br />
+                      {{ reviewer.comment }}
+                    </li>
+                    {% empty %}
+                    <li>No reviews yet</li>
+                    {% endfor %}
+                    <li>
+                      <a
+                        style="font-weight: bold"
+                        target="_blank"
+                        href="{% url 'admin:reviews-vote-view' review_session_id=review_session_id review_item_id=item.id %}"
+                      >
+                        Open Grant review screen
+                      </a>
+                    </li>
+                  </ul>
+                </td>
+                <td>
+                  {{ item.get_status_display }}
+                  <br />
+                  {% if item.approved_type %}({{ item.get_approved_type_display }}){% endif %}
+                </td>
+                <td>
+                  {% if perms.reviews.decision_reviewsession %}
+                  <ul class="status-choices">
+                    {% for status in all_review_statuses %}
+                    <li>
+                      <label>
+                        <input {% if item.status == status.0 %}checked{% endif %}
+                          type="radio"
+                          class="status-decision-radio"
+                          name="decision-{{item.id}}"
+                          id="decision-{{ item.id }}-{{ status.0 }}"
+                          value="{{status.0}}" />
+                        {{ status.1 }}
+                      </label>
+                    </li>
+                    {% endfor %}
+                    <li>
+                      <label>
+                        <input
+                          class="unset-radio"
+                          type="radio"
+                          name="decision-{{ item.id }}"
+                          id="decision-{{ item.id }}-unset"
+                          value="unset"
+                        />
+                        Unset
+                      </label>
+                    </li>
+                  </ul>
+                  {% else %} No permission to change. {% endif %}
+                </td>
+                <td>
+                  {% if perms.reviews.decision_reviewsession %}
+                  <ul
+                    data-item-id="{{ item.id }}"
+                    class="approved-type-choices {% if item.status != 'approved' %}hidden{% endif %}"
+                  >
+                    {% for approved_type in all_approved_types %}
+                    <li>
+                      <label>
+                        <input {% if item.approved_type == approved_type.0 %}checked{% endif %}
+                          type="radio" name="approvedtype-{{item.id}}" value="{{approved_type.0}}" />
+                        {{approved_type.1}}
+                      </label>
+                    </li>
+                    {% endfor %}
+                    <li>
+                      <label>
+                        <input class="unset-radio" type="radio" name="approvedtype-{{item.id}}" value="unset" />
+                          Unset
+                      </label>
+                    </li>
+                  </ul>
+                  {% else %} No permission to change. {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div style="height: 100px"></div>
+  </div>
+  {% if perms.reviews.decision_reviewsession %}
+  <div id="content" class="reviews-bottom-bar colM">
+    <div class="reviews-bottom-bar-content">
+      <div class="submit-row reviews-bottom-bar-confirm-bar">
+        <p>
+          Once done, click the button to save your choices. You can change as
+          many times as you need, no emails will be sent.
+        </p>
+        <input value="Submit choices" type="submit" />
+      </div>
+      <div class="reviews-bottom-bar-stats">
+        <table>
+          <tbody>
+            <tr>
+              <td><h2>Pending status ➡</h2></td>
+              {% for status in all_statuses %}
+              <td>
+                {% if status in all_review_statuses %}
+                <h2 class="pending-grants-num">
+                  {{status.1}}:
+                  <span id="pending-{{status.0}}-grants-num">0</span>
+                </h2>
+                {% endif %}
+              </td>
+              {% endfor %}
+            </tr>
+            <tr>
+              <td><h2>Current status ➡</h2></td>
+              {% for status in all_statuses %}
+              <td>
+                <h2 class="current-grants-num">
+                  {{status.1}}:
+                  <span id="current-{{status.0}}-grants-num">0</span>
+                </h2>
+              </td>
+              {% endfor %}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</form>
 {% endblock %}

--- a/backend/reviews/templates/grants-recap.html
+++ b/backend/reviews/templates/grants-recap.html
@@ -3,418 +3,674 @@
 {% load markdownify %}
 {% load localize countryname get_item %}
 {% block breadcrumbs %}
-<div class="breadcrumbs">
-  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-  &rsaquo; <a href="{% url 'admin:app_list' 'reviews' %}">Reviews</a>
-  &rsaquo; <a href="{% url 'admin:reviews_reviewsession_changelist' %}">Review sessions</a>
-  &rsaquo; <a href="{% url 'admin:reviews_reviewsession_change' review_session_id %}">{{review_session_repr}}</a>
-  &rsaquo; {{title}}
-</div>
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' 'reviews' %}">Reviews</a>
+        &rsaquo; <a href="{% url 'admin:reviews_reviewsession_changelist' %}">Review sessions</a>
+        &rsaquo; <a href="{% url 'admin:reviews_reviewsession_change' review_session_id %}">{{ review_session_repr }}</a>
+        &rsaquo; {{ title }}
+    </div>
 {% endblock %}
 {% block content %}
-
-<style>
-  * {
-    box-sizing: border-box;
-  }
-
-  .status-choices {
-    width: 150px;
-  }
-
-  .approved-type-choices {
-    width: 200px;
-  }
-
-  .status-choices, .approved-type-choices {
-    list-style: none;
-  }
-
-  .status-choices li, .approved-type-choices li {
-    list-style: none;
-  }
-
-  .needs-list {
-    display: inline-block;
-    margin-top: 0;
-  }
-
-  .needs-list li {
-    display: inline-block;
-  }
-
-  .needs-list li::after {
-    content: ',';
-  }
-
-  .needs-list li:last-child:after {
-    display: none;
-  }
-
-  .results-table {
-    width: 100%;
-  }
-
-  .decision-input-wrapper label {
-    display: block;
-  }
-
-  .decision-input-wrapper input {
-    width: 20px;
-    height: 20px;
-    margin-right: 5px;
-  }
-
-  .reviews-bottom-bar {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    z-index: 500;
-    background-color: #417690;
-    color: #fff;
-  }
-
-  .reviews-bottom-bar-content {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .reviews-bottom-bar-stats {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 50px;
-  }
-
-  .reviews-bottom-bar-confirm-bar {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 10px;
-    max-width: 800px;
-  }
-
-  .results-table ul {
-    margin-left: 0;
-    padding: 0;
-    list-style-type: none;
-    list-style-position: inside;
-  }
-
-  .results-table .votes-list {
-    max-width: 800px;
-  }
-
-  .results-item ul li {
-    list-style: none;
-  }
-
-  table.results-table {
-    border-collapse: separate;
-    border-spacing: 0;
-  }
-
-  .results-table thead {
-    position: sticky;
-    top: 43px;
-  }
-
-  .hidden {
-    display: none;
-  }
-
-  .grant-proposal-ranking {
-    display: inline;
-  }
-
-  .grant-proposal-ranking li {
-    display: inline;
-  }
-
-  .grant-proposal-ranking li:after {
-    content: ',';
-  }
-  .grant-proposal-ranking li:last-child:after {
-    display: none;
-  }
-
-  ul.proposals-ranking {
-    margin-left: 30px;
-  }
-  ul.proposals-ranking li {
-    list-style: square;
-  }
-</style>
-<script>
-  window.onload = () => {
-    document.querySelectorAll('.unset-radio').forEach(radio => {
-      radio.addEventListener('click', () => {
-        radio.checked = false;
-
-        const grantId = radio.name.split('-')[1];
-        const grantRow = document.querySelector(`#grant-${grantId}`);
-
-        const originalStatus = grantRow.dataset.originalStatus;
-        const originalApprovedType = grantRow.dataset.originalApprovedType;
-
-        grantRow.querySelector(`.status-decision-radio[value="${originalStatus}"]`).checked = true;
-
-        if (originalApprovedType !== 'None') {
-          grantRow.querySelector(`.approved-type-choices input[value="${originalApprovedType}"]`).checked = true;
+    <style>
+        * {
+            box-sizing: border-box;
         }
 
-        if (originalStatus === "approved") {
-          grantRow.querySelector(`.approved-type-choices`).classList.remove('hidden');
-        } else {
-          grantRow.querySelector(`.approved-type-choices`).classList.add('hidden');
+        .status-choices {
+            width: 150px;
         }
-      });
-    });
 
-    document.querySelectorAll('.status-decision-radio').forEach(radio => {
-      radio.addEventListener('click', () => {
-        const grantId = radio.name.split('-')[1];
-        const approvedTypeSection = document.querySelector(`.approved-type-choices[data-item-id="${grantId}"]`)
-
-        if (radio.value === "approved") {
-          approvedTypeSection.classList.remove('hidden');
-        } else {
-          approvedTypeSection.classList.add('hidden');
+        .approved-type-choices {
+            width: 200px;
         }
-      });
-    });
-  };
-</script>
 
-<ul class="object-tools">
-  <li>
-    <a target="_blank" href="{% url 'admin:grants-summary' %}?conference__id__exact={{ review_session.conference_id }}" class="change-list-object-tools-item">
-      Open Grants Summary
-    </a>
-  </li>
-</ul>
+        .status-choices,
+        .approved-type-choices {
+            list-style: none;
+        }
 
-<form id="changelist-form" method="post" novalidate="">
-  {% csrf_token %}
+        .status-choices li,
+        .approved-type-choices li {
+            list-style: none;
+        }
 
-  <div id="content-main">
-    <div class="module filtered" id="changelist">
-      <div class="changelist-form-container">
-        <div class="results">
-          <table id="result_list" class="results-table">
-            <thead>
-              <tr>
-                <th scope="col">
-                  <div class="text"><span>#</span></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><span>Grant</span></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><a>Score</a></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><span>Votes</span></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><span>Current Status</span></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><span>Decision</span></div>
-                  <div class="clear"></div>
-                </th>
-                <th scope="col">
-                  <div class="text"><span>Approved type</span></div>
-                  <div class="clear"></div>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for item in items %}
-              <tr data-original-status="{{item.status}}" data-original-approved-type="{{item.approved_type}}" class="grant-item" id="grant-{{item.id}}" data-type="{{item.type}}" data-num-of-votes="{{ item.userreview_set.count }}">
-                <td>
-                  {{forloop.counter}}
-                </td>
-                <td class="results-item">
-                  <a
-                    target="_blank"
-                    href="{% url 'admin:grants_grant_change' item.id %}">
-                    <strong>{{item.name}} - {{item.full_name}}</strong>
-                  </a>
-                  <ul>
-                    <li>
-                      <strong>Gender:</strong>
-                      <span>{{item.get_gender_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Age Group:</strong>
-                      <span>{{item.get_age_group_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Occupation:</strong>
-                      <span>{{item.get_occupation_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Travelling From:</strong>
-                      <span>{{item.get_travelling_from_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Country type:</strong>
-                      <span>{{item.get_country_type_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Grant type:</strong>
-                      <span>{{item.get_grant_type_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Needs:</strong>
-                      <ul class="needs-list">
-                        {% if item.need_visa %}
-                          <li>VISA</li>
-                        {% endif %}
-                        {% if item.need_accommodation %}
-                          <li>Accommodation</li>
-                        {% endif %}
-                        {% if item.needs_funds_for_travel %}
-                          <li>Funds for Travel</li>
-                        {% endif %}
-                        {% if not item.need_visa and not item.need_accommodation and not item.needs_funds_for_travel %}
-                          <li>Ticket only</li>
-                        {% endif %}
-                      </ul>
-                    </li>
-                    <li>
-                      <strong>Interested in Volunteering?</strong>
-                      <span>{{item.get_interested_in_volunteering_display}}</span>
-                    </li>
-                    <li>
-                      <strong>Has sent a proposal?</strong>
-                      <span>{{item.has_sent_a_proposal|yesno}}</span>
-                    </li>
-                    {% if item.has_sent_a_proposal %}
-                      <li>
-                        <strong>Proposals Ranking:</strong>
-                        <ul class="proposals-ranking">
-                          {% for proposal_id in item.proposals_ids %}
-                            {% with proposal=proposals|get_item:proposal_id %}
-                              <li>
-                                <strong><a target="_blank" href="{% url 'admin:submissions_submission_change' proposal.id %}">{{proposal.title}}:</a></strong>
-                                <ul class="grant-proposal-ranking">
-                                  {% for ranking in proposal.rankings.all %}
-                                      <li>{{ ranking.tag.name }} {{ ranking.rank }}/{{ ranking.total_submissions_per_tag }}</li>
-                                  {% endfor %}
-                                </ul>
-                              </li>
-                            {% endwith %}
-                          {% endfor %}
-                        </ul>
-                      </li>
-                    {% endif %}
-                  </ul>
-                </td>
+        .needs-list {
+            display: inline-block;
+            margin-top: 0;
+        }
 
-                <td>{{ item.score }}</td>
+        .needs-list li {
+            display: inline-block;
+        }
 
-                <td class="votes-list">
-                  <ul>
-                    {% for reviewer in item.userreview_set.all %}
-                    <li>
-                      <strong>{{reviewer.user.full_name}}</strong> voted
-                      {{reviewer.score.label}}
-                      ({{reviewer.score.numeric_value}})<br />
-                      {{reviewer.comment}}
-                    </li>
-                    {% empty %}
-                    <li>No reviews yet</li>
-                    {% endfor %}
-                    <li>
-                      <a style="font-weight: bold" target="_blank" href="{% url 'admin:reviews-vote-view' review_session_id=review_session_id review_item_id=item.id %}">
-                        Open Grant review screen
-                      </a>
-                    </li>
-                  </ul>
-                </td>
+        .needs-list li::after {
+            content: ',';
+        }
 
-                <td>
-                  {{ item.get_status_display }}<br/>
-                  {% if item.approved_type %}
-                  ({{ item.get_approved_type_display }})
-                  {% endif %}
-                </td>
+        .needs-list li:last-child:after {
+            display: none;
+        }
 
-                <td>
-                  {% if perms.reviews.decision_reviewsession %}
-                    <ul class="status-choices">
-                      {% for status in all_statuses %}
-                        <li>
-                          <label>
-                            <input {% if item.status == status.0 %}checked{% endif %} type="radio" class="status-decision-radio" name="decision-{{item.id}}" value="{{status.0}}" />
-                              {{status.1}}
-                          </label>
-                        </li>
-                      {% endfor %}
-                      <li>
-                        <label>
-                          <input class="unset-radio" type="radio" name="decision-{{item.id}}" value="unset" />
-                            Unset
-                        </label>
-                      </li>
-                    </ul>
-                  {% else %}
-                    No permission to change.
-                  {% endif %}
-                </td>
+        .results-table {
+            width: 100%;
+        }
 
-                <td>
-                  {% if perms.reviews.decision_reviewsession %}
-                    <ul data-item-id="{{item.id}}" class="approved-type-choices {% if item.status != 'approved' %}hidden{% endif %}">
-                      {% for approved_type in all_approved_types %}
-                        <li>
-                          <label>
-                            <input {% if item.approved_type == approved_type.0 %}checked{% endif %} type="radio" name="approvedtype-{{item.id}}" value="{{approved_type.0}}" />
-                              {{approved_type.1}}
-                          </label>
-                        </li>
-                      {% endfor %}
-                      <li>
-                        <label>
-                          <input class="unset-radio" type="radio" name="approvedtype-{{item.id}}" value="unset" />
-                            Unset
-                        </label>
-                      </li>
-                    </ul>
-                  {% else %}
-                    No permission to change.
-                  {% endif %}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+        .decision-input-wrapper label {
+            display: block;
+        }
+
+        .decision-input-wrapper input {
+            width: 20px;
+            height: 20px;
+            margin-right: 5px;
+        }
+
+        .reviews-bottom-bar {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            z-index: 500;
+            background-color: #417690;
+            color: #fff;
+        }
+
+        .reviews-bottom-bar-content {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .reviews-bottom-bar-stats {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 50px;
+        }
+
+        .reviews-bottom-bar-stats tr{
+          background-color: #417690;
+        }
+        .reviews-bottom-bar-stats td{
+          border-bottom: 0;
+        }
+
+        .reviews-bottom-bar-confirm-bar {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 10px;
+            max-width: 800px;
+        }
+
+        .results-table ul {
+            margin-left: 0;
+            padding: 0;
+            list-style-type: none;
+            list-style-position: inside;
+        }
+
+        .results-table .votes-list {
+            max-width: 800px;
+        }
+
+        .results-item ul li {
+            list-style: none;
+        }
+
+        table.results-table {
+            border-collapse: separate;
+            border-spacing: 0;
+        }
+
+        .results-table thead {
+            position: sticky;
+            top: 43px;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .pending-grants-num span {
+          color: #48ff5a;
+        }
+
+        .current-grants-num span {
+          color: #FFA500;
+        }
+
+        .grant-proposal-ranking {
+            display: inline;
+        }
+
+        .grant-proposal-ranking li {
+            display: inline;
+        }
+
+        .grant-proposal-ranking li:after {
+            content: ',';
+        }
+
+        .grant-proposal-ranking li:last-child:after {
+            display: none;
+        }
+
+        ul.proposals-ranking {
+            margin-left: 30px;
+        }
+
+        ul.proposals-ranking li {
+            list-style: square;
+        }
+
+        .opt-filter {
+          display: grid;
+          gap: 10px;
+          grid-template-columns: max-content auto;
+          align-items: center;
+          margin-top: 10px;
+        }
+
+        .opt-filter label + label {
+          margin-left: 10px;
+        }
+
+    </style>
+    <script type="application/javascript">
+        const grantsById = {};
+        let grants;
+
+        const pendingStatusNumRef = {}
+        const currentStatusNumRef = {}
+
+        const getRefs = () => {
+          {% for status in all_review_statuses %}
+          pendingStatusNumRef["{{status.0}}"] = document.querySelector("#pending-{{status.0}}-grants-num");
+          {% endfor %}
+
+          {% for status in all_statuses %}
+            currentStatusNumRef["{{status.0}}"] = document.querySelector("#current-{{status.0}}-grants-num");
+          {% endfor %}
+
+          const acc = {
+            {% for status in all_statuses %}
+            "{{status.0}}": 0,
+            {% endfor %}
+          };
+
+          grants.forEach(grant => {
+            acc[grant.originalStatus]++;
+          });
+
+          {% for status in all_statuses %}
+            currentStatusNumRef["{{status.0}}"].innerText = acc["{{status.0}}"];
+          {% endfor %}
+        };
+
+
+
+        window.addEventListener("load", () => {
+            grants = Object.values(grantsById);
+
+            getRefs();
+            updateBottomBarUI();
+
+            grants.forEach((grantData) => {
+                const grantId = grantData.id;
+                const approvedInput = document.getElementById(
+                    `decision-${grantId}-approved`,
+                );
+                const rejectInput = document.getElementById(
+                    `decision-${grantId}-rejected`,
+                );
+                const unsetInput = document.getElementById(
+                    `decision-${grantId}-unset`,
+                );
+                const waitinglistInput = document.getElementById(
+                    `decision-${grantId}-waiting_list`,
+                );
+                const waitinglistmaybeInput = document.getElementById(
+                    `decision-${grantId}-waiting_list_maybe`,
+                );
+
+                approvedInput.addEventListener("change", () => {
+                    grantData.status = "approved";
+                    updateBottomBarUI();
+                });
+
+                rejectInput.addEventListener("change", () => {
+                    grantData.status = "rejected";
+                    updateBottomBarUI();
+                });
+
+                waitinglistInput.addEventListener("change", () => {
+                    grantData.status = "waiting_list";
+                    updateBottomBarUI();
+                });
+
+                waitinglistInput.addEventListener("change", () => {
+                    grantData.status = "waiting_list_maybe";
+                    updateBottomBarUI();
+                });
+
+                unsetInput.addEventListener("change", () => {
+                    const proposalRow = document.querySelector(`#grant-${grantId}`);
+                    const originalStatus = proposalRow.dataset.originalStatus;
+
+                    if (originalStatus === "approved") {
+                        approvedInput.checked = true;
+                    } else if (originalStatus === "rejected") {
+                        rejectInput.checked = true;
+                    } else if (originalStatus === "waiting_list") {
+                        waitinglistInput.checked = true;
+                    } else if (originalStatus === "waiting_list_maybe") {
+                        waitinglistmaybeInput.checked = true;
+                    }
+
+                    unsetInput.checked = false;
+                    grantData.status = originalStatus;
+                    updateBottomBarUI();
+                });
+            });
+        });
+
+        window.onload = () => {
+            document.querySelectorAll('.unset-radio').forEach(radio => {
+                radio.addEventListener('click', () => {
+                    radio.checked = false;
+
+                    const grantId = radio.name.split('-')[1];
+                    const grantRow = document.querySelector(`#grant-${grantId}`);
+
+                    const originalStatus = grantRow.dataset.originalStatus;
+                    const originalApprovedType = grantRow.dataset.originalApprovedType;
+
+                    grantRow.querySelector(`.status-decision-radio[value="${originalStatus}"]`).checked = true;
+
+                    if (originalApprovedType !== 'None') {
+                        grantRow.querySelector(`.approved-type-choices input[value="${originalApprovedType}"]`).checked = true;
+                    }
+
+                    if (originalStatus === "approved") {
+                        grantRow.querySelector(`.approved-type-choices`).classList.remove('hidden');
+                    } else {
+                        grantRow.querySelector(`.approved-type-choices`).classList.add('hidden');
+                    }
+                });
+            });
+
+            document.querySelectorAll('.status-decision-radio').forEach(radio => {
+                radio.addEventListener('click', () => {
+                    const grantId = radio.name.split('-')[1];
+
+                    const approvedTypeSection = document.querySelector(`.approved-type-choices[data-item-id="${grantId}"]`)
+
+                    if (radio.value === "approved") {
+                        approvedTypeSection.classList.remove('hidden');
+                    } else {
+                        approvedTypeSection.classList.add('hidden');
+                    }
+                });
+            });
+
+            const filterByStatusInputs = [...document.querySelectorAll('input[name="filter-by-status"]')];
+            filterByStatusInputs.forEach(
+                filterByStatusInput => {
+                    filterByStatusInput.addEventListener('change', e => {
+                        e.preventDefault();
+
+                        const filterValue = e.target.value;
+                        const visibleStatuses = filterByStatusInputs.filter(
+                            input => input.checked
+                        ).map(
+                            input => input.value
+                        );
+
+                        document.querySelectorAll('.grant-item').forEach(
+                            grantRow => {
+                                const grantId = parseInt(grantRow.id.split('-')[1], 10);
+                                const grantData = grantsById[grantId];
+
+                                if (visibleStatuses.includes(grantData.originalStatus)) {
+                                    grantRow.classList.remove('hidden')
+                                } else {
+                                    grantRow.classList.add('hidden')
+                                }
+                            }
+                        );
+                    });
+                }
+            );
+
+
+
+        };
+
+        const updateBottomBarUI = () => {
+            const   acc = {}
+            {% for status in all_review_statuses %}
+              acc["{{status.0}}"] = 0
+            {% endfor %}
+
+            const results = grants.reduce(
+                (acc, grant) => {
+                  const grantStatus = grant.status;
+                  acc[grantStatus]++;
+                  return acc
+                },
+                acc,
+            );
+
+            {% for status in all_review_statuses %}
+              pendingStatusNumRef["{{status.0}}"].innerText = results["{{status.0}}"];
+            {% endfor %}
+
+        };
+    </script>
+    <ul class="object-tools">
+        <li>
+            <a target="_blank"
+               href="{% url 'admin:grants-summary' %}?conference__id__exact={{ review_session.conference_id }}"
+               class="change-list-object-tools-item">Open Grants Summary</a>
+        </li>
+    </ul>
+    <form id="changelist-form" method="post" novalidate="">
+        {% csrf_token %}
+        <div id="content-main">
+            <div class="module filtered">
+                <h2>Filters</h2>
+                <div class="opt-filter">
+                    <h3>Show grants with <strong style="text-transform: uppercase">current</strong> status:</h3>
+                    <div>
+                        {% for status in all_statuses %}
+                            <label>
+                                <input checked
+                                       type="checkbox"
+                                       name="filter-by-status"
+                                       value="{{ status.0 }}">
+                                <span>{{ status.1 }}</span>
+                            </label>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            <div class="module filtered" id="changelist">
+                <div class="changelist-form-container">
+                    <div class="results">
+                        <table id="result_list" class="results-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>#</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>Grant</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <a>Score</a>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>Votes</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>Current Status</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>Decision</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="text">
+                                            <span>Approved type</span>
+                                        </div>
+                                        <div class="clear"></div>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in items %}
+                                    <script>
+                                        grantsById[{{item.id}}] = {
+                                            id: {{item.id}},
+                                            status: "{{ item.status }}",
+                                            originalStatus: "{{ item.status }}",
+                                            numOfVotes: {{item.userreview_set.count}},
+                                        };
+                                    </script>
+                                    <tr data-original-status="{{ item.status }}"
+                                        data-original-approved-type="{{ item.approved_type }}"
+                                        class="grant-item"
+                                        id="grant-{{ item.id }}"
+                                        data-type="{{ item.type }}"
+                                        data-num-of-votes="{{ item.userreview_set.count }}">
+                                        <td>{{ forloop.counter }}</td>
+                                        <td class="results-item">
+                                            <a target="_blank" href="{% url 'admin:grants_grant_change' item.id %}">
+                                                <strong>{{ item.name }} - {{ item.full_name }}</strong>
+                                            </a>
+                                            <ul>
+                                                <li>
+                                                    <strong>Gender:</strong>
+                                                    <span>{{ item.get_gender_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Age Group:</strong>
+                                                    <span>{{ item.get_age_group_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Occupation:</strong>
+                                                    <span>{{ item.get_occupation_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Travelling From:</strong>
+                                                    <span>{{ item.get_travelling_from_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Country type:</strong>
+                                                    <span>{{ item.get_country_type_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Grant type:</strong>
+                                                    <span>{{ item.get_grant_type_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Needs:</strong>
+                                                    <ul class="needs-list">
+                                                        {% if item.need_visa %}<li>VISA</li>{% endif %}
+                                                        {% if item.need_accommodation %}<li>Accommodation</li>{% endif %}
+                                                        {% if item.needs_funds_for_travel %}<li>Funds for Travel</li>{% endif %}
+                                                        {% if not item.need_visa and not item.need_accommodation and not item.needs_funds_for_travel %}
+                                                            <li>Ticket only</li>
+                                                        {% endif %}
+                                                    </ul>
+                                                </li>
+                                                <li>
+                                                    <strong>Interested in Volunteering?</strong>
+                                                    <span>{{ item.get_interested_in_volunteering_display }}</span>
+                                                </li>
+                                                <li>
+                                                    <strong>Has sent a proposal?</strong>
+                                                    <span>{{ item.has_sent_a_proposal|yesno }}</span>
+                                                </li>
+                                                {% if item.has_sent_a_proposal %}
+                                                    <li>
+                                                        <strong>Proposals Ranking:</strong>
+                                                        <ul class="proposals-ranking">
+                                                            {% for proposal_id in item.proposals_ids %}
+                                                                {% with proposal=proposals|get_item:proposal_id %}
+                                                                    <li>
+                                                                        <strong><a target="_blank"
+   href="{% url 'admin:submissions_submission_change' proposal.id %}">{{ proposal.title }}:</a></strong>
+                                                                        <ul class="grant-proposal-ranking">
+                                                                            {% for ranking in proposal.rankings.all %}
+                                                                                <li>{{ ranking.tag.name }} {{ ranking.rank }}/{{ ranking.total_submissions_per_tag }}</li>
+                                                                            {% endfor %}
+                                                                        </ul>
+                                                                    </li>
+                                                                {% endwith %}
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </li>
+                                                {% endif %}
+                                            </ul>
+                                        </td>
+                                        <td>{{ item.score }}</td>
+                                        <td class="votes-list">
+                                            <ul>
+                                                {% for reviewer in item.userreview_set.all %}
+                                                    <li>
+                                                        <strong>{{ reviewer.user.full_name }}</strong> voted
+                                                        {{ reviewer.score.label }}
+                                                        ({{ reviewer.score.numeric_value }})
+                                                        <br />
+                                                        {{ reviewer.comment }}
+                                                    </li>
+                                                {% empty %}
+                                                    <li>No reviews yet</li>
+                                                {% endfor %}
+                                                <li>
+                                                    <a style="font-weight: bold"
+                                                       target="_blank"
+                                                       href="{% url 'admin:reviews-vote-view' review_session_id=review_session_id review_item_id=item.id %}">
+                                                        Open Grant review screen
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </td>
+                                        <td>
+                                            {{ item.get_status_display }}
+                                            <br />
+                                            {% if item.approved_type %}({{ item.get_approved_type_display }}){% endif %}
+                                        </td>
+                                        <td>
+                                            {% if perms.reviews.decision_reviewsession %}
+                                                <ul class="status-choices">
+                                                    {% for status in all_review_statuses %}
+                                                        <li>
+                                                            <label>
+                                                                <input {% if item.status == status.0 %}checked{% endif %}
+                                                                       type="radio"
+                                                                       class="status-decision-radio"
+                                                                       name="decision-{{ item.id }}"
+                                                                       id="decision-{{ item.id }}-{{ status.0 }}"
+                                                                       value="{{ status.0 }}" />
+                                                                {{ status.1 }}
+                                                            </label>
+                                                        </li>
+                                                    {% endfor %}
+                                                    <li>
+                                                        <label>
+                                                            <input class="unset-radio"
+                                                                   type="radio"
+                                                                   name="decision-{{ item.id }}"
+                                                                   id="decision-{{ item.id }}-unset"
+                                                                   value="unset" />
+                                                            Unset
+                                                        </label>
+                                                    </li>
+                                                </ul>
+                                            {% else %}
+                                                No permission to change.
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if perms.reviews.decision_reviewsession %}
+                                                <ul data-item-id="{{ item.id }}"
+                                                    class="approved-type-choices {% if item.status != 'approved' %}hidden{% endif %}">
+                                                    {% for approved_type in all_approved_types %}
+                                                        <li>
+                                                            <label>
+                                                                <input {% if item.approved_type == approved_type.0 %}checked{% endif %}
+                                                                       type="radio"
+                                                                       name="approvedtype-{{ item.id }}"
+                                                                       value="{{ approved_type.0 }}" />
+                                                                {{ approved_type.1 }}
+                                                            </label>
+                                                        </li>
+                                                    {% endfor %}
+                                                    <li>
+                                                        <label>
+                                                            <input class="unset-radio"
+                                                                   type="radio"
+                                                                   name="approvedtype-{{ item.id }}"
+                                                                   value="unset" />
+                                                            Unset
+                                                        </label>
+                                                    </li>
+                                                </ul>
+                                            {% else %}
+                                                No permission to change.
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div style="height: 100px"></div>
         </div>
-      </div>
-    </div>
-    <div style="height: 100px"></div>
-  </div>
-  {% if perms.reviews.decision_reviewsession %}
-    <div id="content" class="reviews-bottom-bar colM">
-      <div class="reviews-bottom-bar-content">
-        <div class="submit-row reviews-bottom-bar-confirm-bar">
-          <p>
-            Once done, click the button to save your choices.
-            You can change as many times as you need, no emails will be sent.
-          </p>
-          <input value="Submit choices" type="submit" />
-        </div>
-      </div>
-    </div>
-  {% endif %}
-</form>
+        {% if perms.reviews.decision_reviewsession %}
+            <div id="content" class="reviews-bottom-bar colM">
+                <div class="reviews-bottom-bar-content">
+                    <div class="submit-row reviews-bottom-bar-confirm-bar">
+                        <p>
+                            Once done, click the button to save your choices.
+                            You can change as many times as you need, no emails will be sent.
+                        </p>
+                        <input value="Submit choices" type="submit" />
+                    </div>
+                    <div class="reviews-bottom-bar-stats">
+                        <table>
+                            <tbody>
+                              <tr>
+                                <td><h2>Pending status ➡ </h2></td>
+                                {% for status in all_statuses %}
+                                <td>
+                                  {% if status in all_review_statuses %}
+                                    <h2 class="pending-grants-num">
+                                        {{status.1}}: <span id="pending-{{status.0}}-grants-num">0</span>
+                                    </h2>
+                                    {% endif %}
+                                </td>
+                                {% endfor %}
+                              </tr>
+                              <tr>
+                                <td><h2>Current status ➡ </h2></td>
+                                {% for status in all_statuses %}
+                                <td>
+                                    <h2 class="current-grants-num" >
+                                        {{status.1}}: <span id="current-{{status.0}}-grants-num">0</span>
+                                    </h2>
+                                </td>
+                                {% endfor %}
+                              </tr>
+
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </form>
 {% endblock %}


### PR DESCRIPTION
## Why

- Add filters for the current status 
- Add recap counts for the "pending statuses" (the one that we are selecting) and "current status" (the saved)

![CleanShot 2024-02-16 at 17 37 18](https://github.com/pythonitalia/pycon/assets/28976199/763ed7d3-c4dc-4a37-b366-5ddfcbe6aa6a)

## How to test it

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behaviour and what is not and so on.

You can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
