### PR TITLE
Add GB to list of VAT countries

### DIFF
--- a/pretix/settings.py
+++ b/pretix/settings.py
@@ -43,6 +43,8 @@ CSP_ADDITIONAL_HEADER = "script-src 'self' 'unsafe-inline'"
 # Config
 PRETIX_REGISTRATION = False
 
+VAT_ID_COUNTRIES = EU_COUNTRIES | {"CH", "NO", "GB"}
+
 if "pretix_fattura_elettronica" in INSTALLED_APPS:  # noqa
     INSTALLED_APPS.remove("pretix_fattura_elettronica")  # noqa
 


### PR DESCRIPTION
Not sure why it's not enabled on prexit by default, but 
we do show the VAT ID field on our frontend, so this should be
fine 😊

https://github.com/pretix/pretix/blob/0067c3537dbb05e7a8815aec17728fd75a35eced/src/pretix/base/settings.py#L583-L596
