### PR TITLE
Add Talk Manager info in the schedule builder admin page

### DIFF
--- a/backend/custom_admin/src/components/schedule-builder/item.tsx
+++ b/backend/custom_admin/src/components/schedule-builder/item.tsx
@@ -82,6 +82,11 @@ export const ScheduleItemCard = ({ item, duration }) => {
           </span>
         </li>
       )}
+      <li class="pt-2">
+        <span>
+          [TM: {item.talk_manager.fullname || item.talk_manager.email}]
+        </span>
+      </li>
       <li className="pt-2">
         <Button onClick={openEditLink}>Edit</Button>
       </li>


### PR DESCRIPTION
## What

Add Talk Manager info (name or email) in the schedule builder admin page

