### PR TITLE
point PyDataRoma DNS record to appropriate github pages

### DIFF
--- a/infrastructure/global/domains/python_it/records.tf
+++ b/infrastructure/global/domains/python_it/records.tf
@@ -198,6 +198,14 @@ resource "aws_route53_record" "roma_python_it_cname" {
   ttl     = "3600"
 }
 
+resource "aws_route53_record" "pydataroma_python_it_cname" {
+  zone_id = aws_route53_zone.pythonit.id
+  name    = "pydataroma.python.it"
+  type    = "CNAME"
+  records = ["pydataromacapitale.github.io"]
+  ttl     = "3600"
+}
+
 resource "aws_route53_record" "testcommunity_cname" {
   zone_id = aws_route53_zone.pythonit.id
   name    = "testcommunity.python.it"


### PR DESCRIPTION
## What

As discussed with @patrick91, add the DNS record for the **PyData Roma** website, served from
`pydataroma.python.it`.

As opposed to create the .pydata.it domain as anticipated, we chose to set pydataroma.python.it due to:

* `pydata.it` being already registered by a third party.  
*  simplicity 

## Todo 

As soon as the PR is merged we'll add the CNAME in the repo.

