### PR TITLE
Change conference name from multi-lingual field to CharField

### DIFF
--- a/backend/api/conferences/types.py
+++ b/backend/api/conferences/types.py
@@ -149,7 +149,7 @@ class Keynote:
 class Conference:
     id: strawberry.ID
 
-    name: str = strawberry.field(resolver=make_localized_resolver("name"))
+    name: str
     introduction: str = strawberry.field(
         resolver=make_localized_resolver("introduction")
     )

--- a/backend/conferences/migrations/0055_change_conference_name_to_charfield.py
+++ b/backend/conferences/migrations/0055_change_conference_name_to_charfield.py
@@ -1,0 +1,18 @@
+# Generated manually to change conference name from I18nCharField to CharField
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('conferences', '0054_conference_frontend_revalidate_secret_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='conference',
+            name='name',
+            field=models.CharField(max_length=100, verbose_name='name'),
+        ),
+    ]

--- a/backend/conferences/models/conference.py
+++ b/backend/conferences/models/conference.py
@@ -6,7 +6,7 @@ from model_utils.models import TimeFramedModel, TimeStampedModel
 from timezone_field import TimeZoneField
 
 from helpers.models import GeoLocalizedModel
-from i18n.fields import I18nCharField, I18nTextField
+from i18n.fields import I18nTextField
 
 from .deadline import Deadline, DeadlineStatus
 
@@ -24,7 +24,7 @@ class Conference(GeoLocalizedModel, TimeFramedModel, TimeStampedModel):
         null=True,
     )
 
-    name = I18nCharField(_("name"), max_length=100)
+    name = models.CharField(_("name"), max_length=100)
     code = models.CharField(_("code"), max_length=100, unique=True)
     timezone = TimeZoneField()
     logo = models.ImageField(_("logo"), upload_to=get_upload_to, blank=True)


### PR DESCRIPTION
Convert Conference.name from I18nCharField to models.CharField

## Changes
- Convert Conference.name from I18nCharField to models.CharField
- Remove unused I18nCharField import from conference model
- Create migration 0055 to handle database schema change
- Update GraphQL Conference type to use regular field instead of localized resolver

Closes #4066

Generated with [Claude Code](https://claude.ai/code)