### PR TITLE
Add invitation letter request flag to Grant admin

### DIFF
--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -38,6 +38,7 @@ from django.contrib.admin import SimpleListFilter
 from participants.models import Participant
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from visa.models import InvitationLetterRequest
 
 logger = logging.getLogger(__name__)
 
@@ -591,8 +592,6 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         return obj.has_invitation_letter_request
 
     def get_queryset(self, request):
-        from visa.models import InvitationLetterRequest
-
         qs = (
             super()
             .get_queryset(request)

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -403,7 +403,7 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         "country",
         "is_proposed_speaker",
         "is_confirmed_speaker",
-        "has_invitation_letter_request_flag",
+        "has_sent_invitation_letter_request",
         "emoji_gender",
         "conference",
         "status",
@@ -586,10 +586,11 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     def has_voucher(self, obj: Grant) -> bool:
         return obj.has_voucher
 
-    @admin.display(description="📧", boolean=True)
-    def has_invitation_letter_request_flag(self, obj: Grant) -> bool:
-        """Display flag indicating if user has submitted an invitation letter request"""
-        return obj.has_invitation_letter_request
+    @admin.display(description="📧")
+    def has_sent_invitation_letter_request(self, obj: Grant) -> bool:
+        if obj.has_invitation_letter_request:
+            return "📧"
+        return ""
 
     def get_queryset(self, request):
         qs = (

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -588,9 +588,11 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     @admin.display(description="📧", boolean=True)
     def has_invitation_letter_request_flag(self, obj: Grant) -> bool:
         """Display flag indicating if user has submitted an invitation letter request"""
-        return obj.has_invitation_letter_request()
+        return getattr(obj, 'has_invitation_letter_request', False)
 
     def get_queryset(self, request):
+        from visa.models import InvitationLetterRequest
+        
         qs = (
             super()
             .get_queryset(request)
@@ -612,6 +614,12 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
                         OuterRef("conference_id"),
                     ).filter(
                         user_id=OuterRef("user_id"),
+                    )
+                ),
+                has_invitation_letter_request=Exists(
+                    InvitationLetterRequest.objects.filter(
+                        conference_id=OuterRef("conference_id"),
+                        requester_id=OuterRef("user_id"),
                     )
                 ),
             )

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -31,7 +31,7 @@ from grants.tasks import (
 from schedule.models import ScheduleItem
 from submissions.models import Submission
 from .models import Grant, GrantConfirmPendingStatusProxy
-from django.db.models import Exists, OuterRef, F
+from django.db.models import Exists, OuterRef
 from pretix import user_has_admission_ticket
 
 from django.contrib.admin import SimpleListFilter
@@ -588,11 +588,11 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     @admin.display(description="📧", boolean=True)
     def has_invitation_letter_request_flag(self, obj: Grant) -> bool:
         """Display flag indicating if user has submitted an invitation letter request"""
-        return getattr(obj, 'has_invitation_letter_request', False)
+        return obj.has_invitation_letter_request
 
     def get_queryset(self, request):
         from visa.models import InvitationLetterRequest
-        
+
         qs = (
             super()
             .get_queryset(request)

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -402,6 +402,7 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         "country",
         "is_proposed_speaker",
         "is_confirmed_speaker",
+        "has_invitation_letter_request_flag",
         "emoji_gender",
         "conference",
         "status",
@@ -583,6 +584,11 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
     )
     def has_voucher(self, obj: Grant) -> bool:
         return obj.has_voucher
+
+    @admin.display(description="📧", boolean=True)
+    def has_invitation_letter_request_flag(self, obj: Grant) -> bool:
+        """Display flag indicating if user has submitted an invitation letter request"""
+        return obj.has_invitation_letter_request()
 
     def get_queryset(self, request):
         qs = (

--- a/backend/grants/models.py
+++ b/backend/grants/models.py
@@ -333,6 +333,17 @@ class Grant(TimeStampedModel):
     def current_or_pending_status(self):
         return self.pending_status or self.status
 
+    def has_invitation_letter_request(self):
+        """Check if user has submitted an invitation letter request for this conference"""
+        if not self.user_id:
+            return False
+        
+        from visa.models import InvitationLetterRequest
+        return InvitationLetterRequest.objects.filter(
+            conference=self.conference,
+            requester=self.user
+        ).exists()
+
 
 class GrantConfirmPendingStatusProxy(Grant):
     class Meta:

--- a/backend/grants/models.py
+++ b/backend/grants/models.py
@@ -333,16 +333,6 @@ class Grant(TimeStampedModel):
     def current_or_pending_status(self):
         return self.pending_status or self.status
 
-    def has_invitation_letter_request(self):
-        """Check if user has submitted an invitation letter request for this conference"""
-        if not self.user_id:
-            return False
-        
-        from visa.models import InvitationLetterRequest
-        return InvitationLetterRequest.objects.filter(
-            conference=self.conference,
-            requester=self.user
-        ).exists()
 
 
 class GrantConfirmPendingStatusProxy(Grant):

--- a/backend/grants/models.py
+++ b/backend/grants/models.py
@@ -334,7 +334,6 @@ class Grant(TimeStampedModel):
         return self.pending_status or self.status
 
 
-
 class GrantConfirmPendingStatusProxy(Grant):
     class Meta:
         proxy = True


### PR DESCRIPTION
Display a boolean flag in the Grant admin change list view that indicates whether a request for an invitation letter has been submitted. This helps administrators quickly identify which grants have associated invitation letter requests.

Changes:
- Added has_invitation_letter_request() method to Grant model
- Added has_invitation_letter_request_flag display method to GrantAdmin
- Added flag to admin list_display with 📧 emoji icon

Fixes #4384

Generated with [Claude Code](https://claude.ai/code)