### PR TITLE
Update to Django 6.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,7 +44,7 @@ known-first-party = [
 [project]
 requires-python = ">=3.13.5"
 dependencies = [
-    "django==5.2.8",
+    "django==6.0",
     "django-environ==0.10.0",
     "django-model-utils==5.0.0",
     "django-timezone-field==7.0",


### PR DESCRIPTION
This PR updates Django from 5.2.8 to 6.0.

## Changes
- Updated `backend/pyproject.toml` to specify Django 6.0

## Testing Required
After merging, run:
1. `cd backend && uv lock` to update dependencies
2. `cd backend && uv run pytest` to verify compatibility

Closes #4516

Generated with [Claude Code](https://claude.ai/code)