### PR TITLE
Add deterministic ordering by id to review recap views

### DIFF
--- a/backend/reviews/admin.py
+++ b/backend/reviews/admin.py
@@ -468,7 +468,7 @@ class ReviewSessionAdmin(ConferencePermissionMixin, admin.ModelAdmin):
                     ).values_list("category_id", flat=True)
                 ),
             )
-            .order_by(F("score").desc(nulls_last=True))
+            .order_by(F("score").desc(nulls_last=True), "id")
             .prefetch_related(
                 Prefetch(
                     "userreview_set",
@@ -567,7 +567,7 @@ class ReviewSessionAdmin(ConferencePermissionMixin, admin.ModelAdmin):
                     .values("score")
                 )
             )
-            .order_by(F("score").desc(nulls_last=True))
+            .order_by(F("score").desc(nulls_last=True), "id")
             .prefetch_related(
                 Prefetch(
                     "userreview_set",


### PR DESCRIPTION
Proposals with the same score were appearing in non-deterministic order in the review system recap views. Added secondary sort by `id` to both the grants recap view and proposals recap view to ensure consistent ordering.

Fixes #4535

Generated with [Claude Code](https://claude.ai/code)