### PR TITLE
Add S3 bucket for Docker build cache

### DIFF
--- a/infrastructure/global/buckets/docker-cache.tf
+++ b/infrastructure/global/buckets/docker-cache.tf
@@ -1,0 +1,31 @@
+resource "aws_s3_bucket" "docker_cache" {
+  bucket = "pythonit-docker-cache"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "docker_cache" {
+  bucket = aws_s3_bucket.docker_cache.id
+
+  rule {
+    bucket_key_enabled = false
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "docker_cache" {
+  bucket = aws_s3_bucket.docker_cache.id
+
+  rule {
+    id     = "expire-old-cache"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+output "docker_cache_bucket_name" {
+  value = aws_s3_bucket.docker_cache.bucket
+}


### PR DESCRIPTION
## Summary

Create a new S3 bucket in the global infrastructure for storing Docker BuildKit layer caches.

## Changes

- Add `pythonit-docker-cache` S3 bucket
- Configure AES256 server-side encryption
- 30-day lifecycle policy for automatic cache expiration

Closes #4536

---
Generated with [Claude Code](https://claude.ai/code)