### PR TITLE
include total_grantee_reimbursement_amount in invitation letter template

### DIFF
--- a/backend/visa/models.py
+++ b/backend/visa/models.py
@@ -122,6 +122,15 @@ class InvitationLetterRequest(TimeStampedModel):
 
         return "_".join(sorted(categories)) if len(categories) > 1 else categories[0]
 
+    @property
+    def total_grantee_reimbursement_amount(self):
+        grant = self.user_grant
+
+        if not grant:
+            return None
+
+        return grant.total_grantee_reimbursement_amount
+
     @cached_property
     def user_grant(self):
         return Grant.objects.for_conference(self.conference).of_user(self.user).first()

--- a/backend/visa/tasks.py
+++ b/backend/visa/tasks.py
@@ -151,6 +151,7 @@ def _render_content(content, invitation_letter_request, config):
                 "grant_approved_type": invitation_letter_request.grant_approved_type,
                 "has_accommodation_via_grant": invitation_letter_request.has_accommodation_via_grant(),
                 "has_travel_via_grant": invitation_letter_request.has_travel_via_grant(),
+                "total_grantee_reimbursement_amount": invitation_letter_request.total_grantee_reimbursement_amount,
                 # conference
                 "conference": invitation_letter_request.conference,
             }

--- a/backend/visa/tests/test_models.py
+++ b/backend/visa/tests/test_models.py
@@ -26,6 +26,7 @@ def test_request_on_behalf_of_other():
     assert request.user is None
     assert request.role == "Attendee"
     assert request.has_grant is False
+    assert request.total_grantee_reimbursement_amount is None
 
     # With matching user, it is found
     user = UserFactory(email="example@example.org")
@@ -87,6 +88,13 @@ def test_request_grant_info(
     assert request.has_travel_via_grant() == expected_has_travel
     # grant_approved_type returns sorted categories joined by underscore
     assert request.grant_approved_type == expected_type
+    # total_grantee_reimbursement_amount excludes ticket
+    expected_amount = Decimal(0)
+    if "travel" in categories:
+        expected_amount += Decimal("500")
+    if "accommodation" in categories:
+        expected_amount += Decimal("200")
+    assert request.total_grantee_reimbursement_amount == expected_amount
 
 
 def test_role_for_speakers():


### PR DESCRIPTION
Include grant `total_grantee_reimbursement_amount` in the invitation letter template context so it can be used via `{{total_grantee_reimbursement_amount}}` in dynamic documents.

Closes #4550

Generated with [Claude Code](https://claude.ai/code)