### PR TITLE
Add pydata.it domain zone to global infrastructure

### DIFF
--- a/infrastructure/global/domains/pydata_it/records.tf
+++ b/infrastructure/global/domains/pydata_it/records.tf
@@ -5,3 +5,11 @@ resource "aws_route53_record" "pydata_it_txt" {
   records = ["google-site-verification=Lwmb3AJYmMsxy-guo-bUbV3j-Be1a0nbp9c2f4lPmSM"]
   ttl     = "60"
 }
+
+resource "aws_route53_record" "pydata_it_mx" {
+  zone_id = aws_route53_zone.pydata_it.id
+  name    = "pydata.it"
+  type    = "MX"
+  records = ["1 smtp.google.com."]
+  ttl     = "60"
+}


### PR DESCRIPTION
## Summary
- Add Route53 zone for pydata.it domain
- Add Google site verification TXT record
- Add MX record for Gmail activation (smtp.google.com)

## Test plan
- [ ] Run `terraform plan` on global infrastructure to verify changes
- [ ] Verify domain verification completes in Google Workspace