### PR TITLE
Remove stale vpc module reference

### DIFF
--- a/infrastructure/global/modules.tf
+++ b/infrastructure/global/modules.tf
@@ -14,10 +14,6 @@ module "pydata_it" {
   source = "./domains/pydata_it"
 }
 
-module "vpc" {
-  source = "./vpc"
-}
-
 module "certs_beta" {
   source = "./certs/beta"
 


### PR DESCRIPTION
## Summary
- Remove the `vpc` module reference from `modules.tf` — the `vpc` directory no longer exists, causing `terraform init` to fail

## Test plan
- [ ] Verify `terraform init` succeeds on global infrastructure