### PR TITLE
Add DKIM record for pydata.it domain

### DIFF
--- a/infrastructure/global/domains/pydata_it/records.tf
+++ b/infrastructure/global/domains/pydata_it/records.tf
@@ -6,6 +6,14 @@ resource "aws_route53_record" "pydata_it_txt" {
   ttl     = "60"
 }
 
+resource "aws_route53_record" "pydata_it_dkim" {
+  zone_id = aws_route53_zone.pydata_it.id
+  name    = "google._domainkey.pydata.it"
+  type    = "TXT"
+  records = ["v=DKIM1;k=rsa;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr/vX4g9YEgRabzeWScaBvX4idgMMoTqtlUpRYnbgvoKOY198qYuXR0xtB1JcuVO8Q++9pzVDI2IJS1sFm0uK9uFtWbRLuu2PpyI3sADrJAYtryoyawe2GQgC83yn2aKtAYTdQXp2ZVEEn3TsmcsXPHQ8F+BZP36/5VX2N9VPpaJ0aNVlL9Osk6TXretidOgjrzrcnd+gIp0KU+oEodArZuvimngfk5/5b9m5Nhpg4kRvbZzznjWkGv+UAXjnkgclIt35h5LWkZK/s47V7nIBlAewEEdk93diC5C6JJnxaA9qEGof6RNbj5Qob/r1tZwhVcWHT8O64SzUaH6dsjBsIQIDAQAB"]
+  ttl     = "60"
+}
+
 resource "aws_route53_record" "pydata_it_mx" {
   zone_id = aws_route53_zone.pydata_it.id
   name    = "pydata.it"


### PR DESCRIPTION
## Summary
- Adds a Google DKIM (`google._domainkey`) TXT record for pydata.it to enable email authentication

## Test plan
- [ ] Verify `terraform plan` shows the new DNS record
- [ ] After apply, confirm DKIM record resolves via `dig TXT google._domainkey.pydata.it`