### PR TITLE
Fix HuggingFace token PermissionError in similar talks

### DIFF
--- a/backend/reviews/similar_talks.py
+++ b/backend/reviews/similar_talks.py
@@ -219,7 +219,7 @@ def get_stopwords_for_languages(language_codes: set[str]) -> set[str]:
 @functools.cache
 def get_embedding_model():
     """Get or create the shared embedding model instance."""
-    return SentenceTransformer("all-MiniLM-L6-v2")
+    return SentenceTransformer("all-MiniLM-L6-v2", token=False)
 
 
 def get_embedding_text(submission) -> str:


### PR DESCRIPTION
## Summary
- Pass token=False to SentenceTransformer in get_embedding_model() to prevent it from reading /root/.cache/huggingface/token, which fails with a PermissionError inside Docker
- The all-MiniLM-L6-v2 model is public and does not require authentication

## Test plan
- [ ] Trigger the review recap analysis view and verify the embedding model loads without a PermissionError