### PR TITLE
Lazy-import similar_talks to fix Gunicorn worker OOM on startup

### DIFF
--- a/backend/reviews/admin.py
+++ b/backend/reviews/admin.py
@@ -13,7 +13,6 @@ from django.utils.safestring import mark_safe
 
 from reviews.adapters import get_review_adapter
 from reviews.models import AvailableScoreOption, ReviewSession, UserReview
-from reviews.similar_talks import compute_similar_talks, compute_topic_clusters
 from submissions.models import Submission, SubmissionTag
 from users.admin_mixins import ConferencePermissionMixin
 
@@ -451,6 +450,8 @@ class ReviewSessionAdmin(ConferencePermissionMixin, admin.ModelAdmin):
         conference = review_session.conference
         accepted_submissions = self._get_accepted_submissions(conference)
         force_recompute = request.GET.get("recompute") == "1"
+
+        from reviews.similar_talks import compute_similar_talks, compute_topic_clusters
 
         similar_talks = compute_similar_talks(
             accepted_submissions,


### PR DESCRIPTION
## Summary
- Moves the import of `reviews.similar_talks` from the top of `admin.py` into the view function that uses it
- The module imports heavy ML libraries (sentence-transformers, bertopic, torch) at module level, which caused Gunicorn workers to OOM/timeout during boot and prevented the previous deploy from going live

## Test plan
- [ ] Merge and verify the deploy succeeds (health check passes)
- [ ] Trigger the review recap analysis in admin and verify it still works