### PR TITLE
Fix NLTK data PermissionError in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -73,9 +73,10 @@ ENV LIBRARY_PATH=/lib:/usr/lib LD_LIBRARY_PATH=/lib:/usr/lib
 RUN apt-get update -y && apt-get install -y curl
 
 RUN groupadd -r app && useradd -r -g app app && mkdir -p ${FUNCTION_DIR} && chown -R app:app ${FUNCTION_DIR} \
-    && mkdir -p /home/app/.cache/huggingface && chown -R app:app /home/app/.cache
+    && mkdir -p /home/app/.cache/huggingface /home/app/nltk_data && chown -R app:app /home/app/.cache /home/app/nltk_data
 
 ENV HF_HOME=/home/app/.cache/huggingface
+ENV NLTK_DATA=/home/app/nltk_data
 
 COPY --chown=app:app --from=js-stage ${FUNCTION_DIR}/dist/*.html ${FUNCTION_DIR}/custom_admin/templates/astro/
 COPY --chown=app:app --from=js-stage ${FUNCTION_DIR}/dist/widgets/*.html ${FUNCTION_DIR}/custom_admin/templates/astro/widgets/


### PR DESCRIPTION
## Summary
- Add NLTK_DATA env var pointing to /home/app/nltk_data with correct ownership for the app user
- Same root cause as #4574: su -p preserves HOME=/root, so NLTK defaults to /root/nltk_data which the app user cannot write to
- docs https://www.nltk.org/data.html

## Test plan
- Deploy and trigger similar_talks analysis that downloads NLTK stopwords
- Verify no PermissionError for /root/nltk_data in logs