### PR TITLE
fix: filter out unpublished pages in cms_page and news_article queries

### DIFF
--- a/backend/api/cms/news/queries/news_article.py
+++ b/backend/api/cms/news/queries/news_article.py
@@ -11,7 +11,7 @@ def news_article(hostname: str, slug: str, language: str) -> NewsArticle | None:
     if not site:
         raise ValueError(f"Site {hostname} not found")
 
-    article = NewsArticleModel.objects.in_site(site).filter(slug=slug).first()
+    article = NewsArticleModel.objects.in_site(site).filter(slug=slug, live=True).first()
 
     if not article:
         return None

--- a/backend/api/cms/page/queries/cms_page.py
+++ b/backend/api/cms/page/queries/cms_page.py
@@ -20,7 +20,7 @@ def cms_page(
     if not site:
         return SiteNotFoundError(message=f"Site `{hostname}` not found")
 
-    page = GenericPageModel.objects.in_site(site).filter(slug=slug).first()
+    page = GenericPageModel.objects.in_site(site).filter(slug=slug, live=True).first()
 
     if not page:
         return None


### PR DESCRIPTION
Fixes #4577

Add `live=True` filter to the initial queryset in both `cms_page` and `news_article` GraphQL queries to ensure draft/unpublished pages are never returned.

Previously, unpublished pages could still be fetched by slug even though only the translated version was being filtered for live status.

Generated with [Claude Code](https://claude.ai/code)