### PR TITLE
feat(job-board): add Apply Now button at top of job description

### DIFF
--- a/frontend/src/components/job-board-layout/index.tsx
+++ b/frontend/src/components/job-board-layout/index.tsx
@@ -72,6 +72,16 @@ export const JobBoardLayout = ({
               <Text size={2} color="grey-500">
                 {jobListing.company}
               </Text>
+              <Spacer size="small" />
+              {jobListing.applyUrl && (
+                <Button
+                  target="_blank"
+                  href={jobListing.applyUrl}
+                  variant="secondary"
+                >
+                  <FormattedMessage id="jobboard.applyNow" />
+                </Button>
+              )}
               <Spacer size="large" />
               <Article>
                 <StyledHTMLText


### PR DESCRIPTION
Adds an additional "Apply now" button below the company name in the job board detail view. This provides users with a convenient way to apply without scrolling through the entire job description.

Closes #4579

Generated with [Claude Code](https://claude.ai/code)