### PR TITLE
fix: hide proposal scheduled time if submission is not accepted

### DIFF
--- a/frontend/src/components/my-proposals-profile-page-handler/my-proposals-table.tsx
+++ b/frontend/src/components/my-proposals-profile-page-handler/my-proposals-table.tsx
@@ -37,7 +37,8 @@ export const MyProposalsTable = ({ submissions }: Props) => {
     <Table
       cols={4}
       rowGetter={(row) => {
-        const inSchedule = row.scheduleItems.length > 0;
+        const isAccepted = row.status === "accepted";
+        const inSchedule = isAccepted && row.scheduleItems.length > 0;
         return [
           <div>
             <EventTag type={row.type.name.toLowerCase()} />


### PR DESCRIPTION
Fixes #4583

Only show the scheduled time and "View Invitation" button in My Proposals when the submission status is "accepted".

Generated with [Claude Code](https://claude.ai/code)