### PR TITLE
feat: add is_scheduled column to submission admin

### DIFF
--- a/backend/submissions/admin.py
+++ b/backend/submissions/admin.py
@@ -222,6 +222,7 @@ class SubmissionAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         "speaker_display_name",
         "type",
         "status",
+        "is_scheduled",
         "conference",
         "open_submission",
         "inline_tags",
@@ -307,6 +308,15 @@ class SubmissionAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         return ", ".join([tag.name for tag in obj.tags.all()])
 
     @admin.display(
+        description="Scheduled",
+        boolean=True,
+    )
+    def is_scheduled(self, obj):
+        # Use bool() on all() to utilize prefetch_related data instead of exists()
+        # which would issue an additional query
+        return bool(obj.schedule_items.all())
+
+    @admin.display(
         description="Open",
     )
     def open_submission(self, obj):  # pragma: no cover
@@ -318,7 +328,7 @@ class SubmissionAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         )
 
     def get_queryset(self, request):
-        return super().get_queryset(request).prefetch_related("tags")
+        return super().get_queryset(request).prefetch_related("tags", "schedule_items")
 
     class Media:
         js = ["admin/js/jquery.init.js"]

--- a/backend/submissions/admin.py
+++ b/backend/submissions/admin.py
@@ -309,12 +309,13 @@ class SubmissionAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
 
     @admin.display(
         description="Scheduled",
-        boolean=True,
     )
     def is_scheduled(self, obj):
-        # Use bool() on all() to utilize prefetch_related data instead of exists()
-        # which would issue an additional query
-        return bool(obj.schedule_items.all())
+        schedule_items = obj.schedule_items.all()
+        if not schedule_items:
+            return "-"
+        times = [item.start.strftime("%Y-%m-%d %H:%M") for item in schedule_items]
+        return ", ".join(times)
 
     @admin.display(
         description="Open",
@@ -328,7 +329,9 @@ class SubmissionAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         )
 
     def get_queryset(self, request):
-        return super().get_queryset(request).prefetch_related("tags", "schedule_items")
+        return super().get_queryset(request).prefetch_related(
+            "tags", "schedule_items__slot__day"
+        )
 
     class Media:
         js = ["admin/js/jquery.init.js"]

--- a/backend/submissions/tests/test_admin.py
+++ b/backend/submissions/tests/test_admin.py
@@ -3,7 +3,9 @@ from conferences.tests.factories import ConferenceFactory
 from notifications.tests.factories import EmailTemplateFactory
 from notifications.models import EmailTemplateIdentifier, SentEmail
 import pytest
+from schedule.tests.factories import ScheduleItemFactory
 from submissions.admin import (
+    SubmissionAdmin,
     apply_and_notify_status_change,
     send_proposal_in_waiting_list_email_action,
     send_proposal_rejected_email_action,
@@ -12,6 +14,25 @@ from submissions.models import Submission
 from submissions.tests.factories import SubmissionFactory
 
 pytestmark = pytest.mark.django_db
+
+
+def test_is_scheduled_returns_true_when_submission_has_schedule_items():
+    submission = SubmissionFactory()
+    ScheduleItemFactory(
+        submission=submission,
+        conference=submission.conference,
+        type="submission",
+    )
+
+    admin = SubmissionAdmin(model=Submission, admin_site=None)
+    assert admin.is_scheduled(submission) is True
+
+
+def test_is_scheduled_returns_false_when_submission_has_no_schedule_items():
+    submission = SubmissionFactory()
+
+    admin = SubmissionAdmin(model=Submission, admin_site=None)
+    assert admin.is_scheduled(submission) is False
 
 
 def test_send_proposal_rejected_email_action(rf, mocker):

--- a/backend/submissions/tests/test_admin.py
+++ b/backend/submissions/tests/test_admin.py
@@ -16,23 +16,24 @@ from submissions.tests.factories import SubmissionFactory
 pytestmark = pytest.mark.django_db
 
 
-def test_is_scheduled_returns_true_when_submission_has_schedule_items():
+def test_is_scheduled_returns_datetime_when_submission_has_schedule_items():
     submission = SubmissionFactory()
-    ScheduleItemFactory(
+    schedule_item = ScheduleItemFactory(
         submission=submission,
         conference=submission.conference,
         type="submission",
     )
 
     admin = SubmissionAdmin(model=Submission, admin_site=None)
-    assert admin.is_scheduled(submission) is True
+    expected_time = schedule_item.start.strftime("%Y-%m-%d %H:%M")
+    assert admin.is_scheduled(submission) == expected_time
 
 
-def test_is_scheduled_returns_false_when_submission_has_no_schedule_items():
+def test_is_scheduled_returns_dash_when_submission_has_no_schedule_items():
     submission = SubmissionFactory()
 
     admin = SubmissionAdmin(model=Submission, admin_site=None)
-    assert admin.is_scheduled(submission) is False
+    assert admin.is_scheduled(submission) == "-"
 
 
 def test_send_proposal_rejected_email_action(rf, mocker):


### PR DESCRIPTION
Add a new column in the submission admin that shows whether a submission is scheduled in the conference.

Closes #4585

Generated with [Claude Code](https://claude.ai/code)