### PR TITLE
Remove quote marks and styling from badge tagline

### DIFF
--- a/frontend/src/components/badge/index.tsx
+++ b/frontend/src/components/badge/index.tsx
@@ -156,27 +156,7 @@ export const Badge = ({
             }}
             className="!text-[13px] [&>span]:text-[13px] badge-tagline"
           >
-            <Balancer>
-              <span
-                style={{
-                  color: BADGE_TYPE_TO_COLOR[role],
-                  opacity: tagline ? 1 : 0,
-                }}
-                className="badge-tagline-quote"
-              >
-                “
-              </span>
-              {tagline.substring(0, 250)}
-              <span
-                style={{
-                  color: BADGE_TYPE_TO_COLOR[role],
-                  opacity: tagline ? 1 : 0,
-                }}
-                className="badge-tagline-quote"
-              >
-                ”
-              </span>
-            </Balancer>
+            <Balancer>{tagline.substring(0, 250)}</Balancer>
           </div>
         </div>
         <div

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -60,6 +60,3 @@ body:has(.brochure-page) {
 .badge-tower-right {
   transform: translate(5%, 60px);
 }
-.badge-tagline-quote {
-  font-weight: 400;
-}


### PR DESCRIPTION
## What

Simplified the badge tagline rendering by removing the decorative quote marks (`"`) that surrounded the tagline text. Also removed the associated `.badge-tagline-quote` CSS class and its font-weight styling that is no longer needed.

The tagline now displays as plain text without quotes, making the component cleaner and reducing unnecessary DOM elements.

## ToDo

- [ ] Verify badge appearance in design/preview

https://claude.ai/code/session_01NDkgpco9wHrNPbP9zEru7h