### PR TITLE
feat(schedule): add attendees count column to workshop admin list

### DIFF
--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -494,7 +494,7 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
         if obj.actual_attendees_total_capacity is None:
             return None
 
-        return obj.actual_attendees_total_capacity - obj.attendees.count()
+        return obj.actual_attendees_total_capacity - obj.attendees_count_annotation
 
     def save_form(self, request, form, change):
         if form.cleaned_data["new_slot"]:

--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -1,7 +1,7 @@
 from django.db import transaction
 from custom_admin.admin import validate_single_conference_selection
 from import_export.resources import ModelResource
-from django.db.models import Prefetch
+from django.db.models import Count, Prefetch
 from typing import Dict
 from django import forms
 from django.contrib import admin, messages
@@ -317,6 +317,7 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
         "talk_manager",
         "type",
         "submission",
+        "attendees_count",
     )
     list_filter = ("conference", "status", "type")
     ordering = ("conference", "slot")
@@ -399,7 +400,12 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
     )
 
     def get_queryset(self, request):
-        return super().get_queryset(request).prefetch_related("rooms")
+        return (
+            super()
+            .get_queryset(request)
+            .prefetch_related("rooms")
+            .annotate(attendees_count_annotation=Count("attendees", distinct=True))
+        )
 
     def get_urls(self):
         return [
@@ -484,7 +490,7 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
 
         return TemplateResponse(request, "email-speakers.html", context)
 
-    def spaces_left(self, obj):
+    def spaces_left(self, obj: ScheduleItem) -> int | None:
         if obj.actual_attendees_total_capacity is None:
             return None
 
@@ -503,10 +509,18 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
 
         return return_value
 
-    def speakers_names(self, obj):
+    def speakers_names(self, obj: ScheduleItem) -> str:
         return ", ".join([speaker.display_name for speaker in obj.speakers])
 
-    def invitation_link(self, obj):
+    @admin.display(description="Attendees")
+    def attendees_count(self, obj: ScheduleItem) -> str:
+        count = obj.attendees_count_annotation
+        capacity = obj.actual_attendees_total_capacity
+        if capacity is None:
+            return str(count)
+        return f"{count} / {capacity}"
+
+    def invitation_link(self, obj: ScheduleItem) -> str:
         return f"https://pycon.it/schedule/invitation/{obj.submission.hashid}"
 
 


### PR DESCRIPTION
## Summary

- Adds an **Attendees** column to the `ScheduleItem` admin list view, visible when filtering by `type=training` (workshops)
- Displays registered attendees as `N / capacity` when a capacity is set, or just `N` when there is none
- Annotates the queryset with `Count("attendees", distinct=True)` to avoid N+1 queries — a single SQL `COUNT` per row rather than a separate query per row

## Test plan

- [ ] Open `/admin/schedule/scheduleitem/?type__exact=training` and verify the new **Attendees** column appears
- [ ] Check that items with `attendees_total_capacity` set show `N / capacity` format
- [ ] Check that items without a capacity show just the count