### PR TITLE
fix(build): approve pnpm 11 build scripts for native deps

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR ${FUNCTION_DIR}
 
 RUN npm install -g pnpm
 
-COPY custom_admin/package.json custom_admin/pnpm-lock.yaml ./
+COPY custom_admin/package.json custom_admin/pnpm-lock.yaml custom_admin/pnpm-workspace.yaml ./
 
 RUN pnpm install
 

--- a/backend/custom_admin/pnpm-workspace.yaml
+++ b/backend/custom_admin/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary

- The backend Docker build has been failing with `[ERR_PNPM_IGNORED_BUILDS]` because `npm install -g pnpm` in the Dockerfile now installs pnpm v11, which **blocks build scripts for native packages by default** (a security change introduced in pnpm 10+)
- The affected packages are `@parcel/watcher`, `esbuild`, and `sharp`
- Fix: add `pnpm-workspace.yaml` with `allowBuilds` (generated via `pnpm approve-builds --all`) and update the Dockerfile `COPY` to include it

## Changes

- `backend/custom_admin/pnpm-workspace.yaml` — new file, pnpm 11's approval mechanism for native build scripts
- `backend/Dockerfile` — copy `pnpm-workspace.yaml` into the Docker build context alongside `package.json` and `pnpm-lock.yaml`

## Test plan

- [ ] Verify the `Build backend` CI job passes on this PR