### PR TITLE
Update ScheduleItem admin: title first column, add rooms list

### DIFF
--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -308,11 +308,12 @@ class ScheduleItemAdminForm(forms.ModelForm):
 @admin.register(ScheduleItem)
 class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
     list_display = (
-        "conference",
         "title",
+        "conference",
         "status",
         "language",
         "slot",
+        "rooms_list",
         "speakers_names",
         "talk_manager",
         "type",
@@ -511,6 +512,10 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
 
     def speakers_names(self, obj: ScheduleItem) -> str:
         return ", ".join([speaker.display_name for speaker in obj.speakers])
+
+    @admin.display(description="Rooms")
+    def rooms_list(self, obj: ScheduleItem) -> str:
+        return ", ".join([room.name for room in obj.rooms.all()])
 
     @admin.display(description="Attendees")
     def attendees_count(self, obj: ScheduleItem) -> str:


### PR DESCRIPTION
## Summary
- Move title to be the first column in the ScheduleItem admin list view
- Add rooms list column to display room names

Closes #4655

Generated with [Claude Code](https://claude.ai/code)