### PR TITLE
Fix crash in Django admin when ScheduleItem has None speakers

### DIFF
--- a/backend/schedule/models.py
+++ b/backend/schedule/models.py
@@ -347,7 +347,7 @@ class ScheduleItem(TimeStampedModel):
         speakers.extend(
             [speaker.user for speaker in self.additional_speakers.order_by("id").all()]
         )
-        return speakers
+        return [speaker for speaker in speakers if speaker is not None]
 
     def clean(self):
         if self.type == ScheduleItem.TYPES.submission and not self.submission:


### PR DESCRIPTION
Filter out None values from the speakers property to prevent AttributeError when the admin's speakers_names method calls display_name on invalid speaker objects.

Fixes #4657

Generated with [Claude Code](https://claude.ai/code)