### PR TITLE
Fix backend build: migrate DjangoAdminEditorModal to Radix Dialog

### DIFF
--- a/backend/custom_admin/src/components/shared/django-admin-editor-modal/index.tsx
+++ b/backend/custom_admin/src/components/shared/django-admin-editor-modal/index.tsx
@@ -1,7 +1,7 @@
 import { useApolloClient } from "@apollo/client";
-import { useEffect, useMemo, useState } from "react";
+import { Dialog, VisuallyHidden } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
 
-import { Modal } from "../modal";
 import { DjangoAdminEditorContext, useDjangoAdminEditor } from "./context";
 
 export const DjangoAdminEditorProvider = ({ children }) => {
@@ -49,12 +49,13 @@ export const DjangoAdminEditorModal = () => {
   const itemUrl = `${baseUrl}/admin${url}`;
 
   return (
-    <Modal onClose={onClose} isOpen={isOpen}>
-      <iframe
-        title="Admin view"
-        src={itemUrl}
-        className="w-[90vw] h-[90vh] z-[100]"
-      />
-    </Modal>
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Content maxWidth="90vw" width="90vw">
+        <VisuallyHidden>
+          <Dialog.Title>Admin view</Dialog.Title>
+        </VisuallyHidden>
+        <iframe title="Admin view" src={itemUrl} className="w-full h-[85vh]" />
+      </Dialog.Content>
+    </Dialog.Root>
   );
 };


### PR DESCRIPTION
## Summary

The backend Docker build on `main` is failing ([run 27280034017](https://github.com/pythonitalia/pycon/actions/runs/27280034017/job/80571726338)) with:

```
Could not resolve "../modal" from "src/components/shared/django-admin-editor-modal/index.tsx"
```

#4664 (Migrate custom_admin Schedule Builder to Radix UI) deleted `shared/modal.tsx` but missed `django-admin-editor-modal/index.tsx`, which still imported it. This migrates that last consumer to the same Radix `Dialog` pattern used by the rest of #4664.

The iframe modal keeps its ~90vw footprint via `Dialog.Content width/maxWidth`; a visually hidden `Dialog.Title` keeps Radix's accessibility requirement satisfied. Closing the dialog still triggers the `ConferenceSchedule` refetch.

## Test plan

- [x] `pnpm build` in `backend/custom_admin` (node:23 container, same as Dockerfile js-stage) — previously failed at the client vite stage, now completes
- [x] Biome check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)