### PR TITLE
Fix schedule builder Radix regressions

### DIFF
--- a/backend/custom_admin/src/components/schedule-builder/item.tsx
+++ b/backend/custom_admin/src/components/schedule-builder/item.tsx
@@ -220,7 +220,11 @@ export const ScheduleItemCard = ({
   };
 
   return (
-    <Card ref={dragRef} size="1" style={{ opacity, cursor: "grab" }}>
+    <Card
+      ref={dragRef}
+      size="1"
+      style={{ opacity, cursor: "grab", height: "100%" }}
+    >
       <Flex direction="column" gap="1" align="start">
         {availability === "unavailable" && (
           <Flex align="center" gap="1">

--- a/backend/custom_admin/src/components/shared/django-admin-editor-modal/index.tsx
+++ b/backend/custom_admin/src/components/shared/django-admin-editor-modal/index.tsx
@@ -40,13 +40,8 @@ export const DjangoAdminEditorModal = () => {
     });
   };
 
-  if (!url) {
-    return null;
-  }
-
   const baseUrl =
     document.location.ancestorOrigins?.[0] || document.location.origin;
-  const itemUrl = `${baseUrl}/admin${url}`;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -54,7 +49,16 @@ export const DjangoAdminEditorModal = () => {
         <VisuallyHidden>
           <Dialog.Title>Admin view</Dialog.Title>
         </VisuallyHidden>
-        <iframe title="Admin view" src={itemUrl} className="w-full h-[85vh]" />
+        {/* url is null while the dialog animates closed; keep Dialog.Root
+            mounted so Radix can finish closing and restore body pointer
+            events — unmounting it while open leaves the page unclickable. */}
+        {url && (
+          <iframe
+            title="Admin view"
+            src={`${baseUrl}/admin${url}`}
+            className="w-full h-[85vh]"
+          />
+        )}
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/backend/custom_admin/src/custom-styles.css
+++ b/backend/custom_admin/src/custom-styles.css
@@ -12,7 +12,20 @@
     opacity: 0;
     animation: rt-fade-out 200ms cubic-bezier(0.16, 1, 0.3, 1);
   }
-  z-index: 30;
+  /* Must beat the schedule grid's z-[100] sticky headers: .radix-themes
+     creates no stacking context, so the grid competes with portals at the
+     body level. 500 matches the old shared Modal overlay. */
+  z-index: 500;
+}
+
+/* Portalled popper content (Select, DropdownMenu, Popover, Tooltip) has no
+   z-index in Radix Themes and relies on DOM order, so it paints below the
+   dialog overlay once that has an explicit z-index. The popper wrapper copies
+   the content's computed z-index, so a class rule here is enough. */
+.rt-PopperContent,
+.rt-SelectContent,
+.rt-TooltipContent {
+  z-index: 510;
 }
 
 .rt-BaseDialogContent {


### PR DESCRIPTION
## Summary

Fixes regressions introduced by #4664 (Radix UI migration) in the schedule builder.

### 1. Items longer than their slot no longer stretched for the entire duration

The old markup painted the full grid-row span via `bg-slate-200` on both the wrapper div and the inner `<ul>`. The migration removed the wrapper background and replaced the `<ul>` with a Radix `Card`, which only takes its natural content height — so a multi-slot item rendered as a short card at the top of its span.

Fix: make the `Card` fill its grid area with `height: 100%`. The other `ScheduleItemCard` usage (pending items basket) is unaffected since its parent has auto height.

This also removes the invisible dead zone: the item wrapper spans the full duration with `z-50`, so the placeholders visible "through" it were not clickable.

### 2. Drop/Add cells sometimes unresponsive (no hover, no click)

`DjangoAdminEditorModal` returned `null` as soon as `url` was cleared, unmounting the open Radix Dialog mid-close. A modal Radix Dialog sets `pointer-events: none` on `<body>`, and an abrupt unmount can leave it stuck — after closing an "Edit" dialog the whole page stops responding to hover/clicks until reload.

Fix: keep `Dialog.Root` mounted and drive it via the `open` prop (same pattern `AddItemModal` already uses), guarding only the iframe on `url`.

### 3. "Type" dropdown options in the "Add event to schedule" modal open behind the dialog

Before the migration this was a native `<select>`, which the browser always renders on top. The Radix Select content is portalled with no z-index (Radix Themes stacks portals by DOM order), while `custom-styles.css` gives the dialog overlay an explicit `z-index: 30` — so the options painted behind the modal and could not be clicked.

Fix: raise the dialog overlay to `z-index: 500` (the old shared `Modal` level, also covering the schedule grid's `z-[100]` sticky headers, which otherwise paint over the open dialog) and give popper content (Select, DropdownMenu, Popover, Tooltip) `z-index: 510` so it stacks above open dialogs. The popper wrapper copies the content's computed z-index, so class rules are sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)