### PR TITLE
refactor: 2 improvements across 2 files

### DIFF
--- a/backend/api/schedule/mutations/create_schedule_slot.py
+++ b/backend/api/schedule/mutations/create_schedule_slot.py
@@ -16,7 +16,7 @@ class CreateScheduleSlotInput:
     type: str
 
 
-@strawberry.field(permission_classes=[CanEditSchedule])
+@strawberry.mutation(permission_classes=[CanEditSchedule])
 def create_schedule_slot(info: Info, input: CreateScheduleSlotInput) -> Day:
     conference_id = input.conference_id
     day = DayModel.objects.for_conference(conference_id).get(id=input.day_id)

--- a/backend/api/schedule/mutations/star_schedule_item.py
+++ b/backend/api/schedule/mutations/star_schedule_item.py
@@ -5,7 +5,7 @@ from schedule.models import ScheduleItemStar
 import strawberry
 
 
-@strawberry.field(permission_classes=[IsAuthenticated])
+@strawberry.mutation(permission_classes=[IsAuthenticated])
 def star_schedule_item(info: Info, id: strawberry.ID) -> OperationSuccess:
     user_id = info.context.request.user.id
 


### PR DESCRIPTION
## Summary

refactor: 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `backend/api/schedule/mutations/star_schedule_item.py:L11`

The file `star_schedule_item.py` uses `@strawberry.field` instead of `@strawberry.mutation` for a mutation operation, while `unstar_schedule_item.py` correctly uses `@strawberry.mutation`. This inconsistency can lead to confusion in the GraphQL schema introspection, where mutations may appear as queries rather than mutations. UI clients relying on schema introspection for operation categorization will be affected.

## Solution

Change `@strawberry.field` to `@strawberry.mutation` to maintain consistency with other mutation definitions and ensure proper GraphQL schema generation.

## Changes

- `backend/api/schedule/mutations/star_schedule_item.py` (modified)
- `backend/api/schedule/mutations/create_schedule_slot.py` (modified)