### PR TITLE
ci: speed up backend image build (step 1)

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -20,8 +20,6 @@ jobs:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: eu-central-1
-      - name: Set up QEMU dependency
-        uses: docker/setup-qemu-action@v3
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
       - name: Set up Docker Buildx
@@ -36,6 +34,6 @@ jobs:
           provenance: false
           push: true
           tags: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/pythonit/pycon-backend:arm-${{ inputs.githash }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/pythonit/pycon-backend:buildcache
+          cache-to: type=registry,ref=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/pythonit/pycon-backend:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
           platforms: linux/arm64


### PR DESCRIPTION
## What

Two changes to `.github/workflows/build-backend.yml`:

1. **Move build cache from GitHub Actions cache → ECR registry** (same `pycon-backend` repo, `:buildcache` tag).
2. **Drop the QEMU setup step** — the runner is `ubuntu-24.04-arm` building `linux/arm64` natively, no emulation needed.

## Why

The backend image build was taking **~12 min**. Almost none of it was compiling — it was moving big layers around. Breakdown of the `Build and push` step (~11m55s):

| Phase | Time |
|---|---|
| Real build work (`uv sync`, schema, `.venv` copy, collectstatic) | ~2.5 min |
| Export image → ECR | ~3.5 min |
| **Export build cache → GitHub Actions (`mode=max`)** | **~7 min** |

The dominant cost was exporting the cache to the GHA backend: `mode=max` re-uploads every layer of every stage to a separate, rate-limited store. The heavy `.venv` layer (multi-GB — `sentence-transformers` pulls in torch + transformers) got uploaded **twice**: once to ECR as the image, once to GHA as cache.

Pointing the cache at the **same ECR repo** lets the image push and cache export share one content-addressed store, so shared layers upload **once**, and ECR isn't throttled like the GHA cache backend. Expected saving ~3–4 min/build.

### Notes
- `image-manifest=true,oci-mediatypes=true` are **required** — ECR rejects buildkit's legacy cache-manifest format.
- `mode=max` kept on purpose: this is a multi-stage build; `min` would stop caching the intermediate `uv sync` / `pnpm build` stages, which would then re-run on every ephemeral CI runner.
- First run after merge: the `:buildcache` tag doesn't exist yet → cache miss, builds fresh, creates it. Speedup lands on run #2+.

## This is step 1

This is the **first step**. The real fix is shrinking the image: the multi-GB `.venv` (torch/transformers via `sentence-transformers`, plus scikit-learn/nltk) bloats **every** phase — `.venv` copy, image export, image push, and cache export. **Step 2 will move the ML stuff out** (CPU-only torch / a separate ML worker image) so the web image stays small. That's the change that cuts every phase regardless of cache backend; this PR just stops the bleeding on the cache export first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)