### PR TITLE
Generic form system: friendlier options editing in admin (PR 6)

### DIFF
--- a/backend/generic_forms/admin.py
+++ b/backend/generic_forms/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
+from generic_forms.forms import FormQuestionInlineForm
 from generic_forms.models import Form, FormAnswer, FormQuestion
 
 
 class FormQuestionInline(admin.TabularInline):
     model = FormQuestion
+    form = FormQuestionInlineForm
     extra = 1
     fields = (
         "label",

--- a/backend/generic_forms/forms.py
+++ b/backend/generic_forms/forms.py
@@ -1,0 +1,48 @@
+from django import forms
+from django.utils.text import slugify
+
+from generic_forms.models import FormQuestion
+
+
+class OptionsField(forms.Field):
+    """Edit select/multi-select options as one option per line, either as
+    "id | label" or just "label" (the id is slugified from the label).
+    Stored as the usual [{"id": ..., "label": ...}] JSON.
+    """
+
+    widget = forms.Textarea(attrs={"rows": 4, "placeholder": "vegan | Vegan\nVeggie"})
+
+    def prepare_value(self, value):
+        if isinstance(value, list):
+            return "\n".join(f"{option['id']} | {option['label']}" for option in value)
+        return value
+
+    def to_python(self, value):
+        if not value:
+            return []
+        if isinstance(value, list):
+            return value
+
+        options = []
+        for line in value.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if "|" in line:
+                option_id, _, label = line.partition("|")
+                options.append({"id": option_id.strip(), "label": label.strip()})
+            else:
+                options.append({"id": slugify(line), "label": line})
+        return options
+
+
+class FormQuestionInlineForm(forms.ModelForm):
+    options = OptionsField(
+        required=False,
+        help_text='One option per line: "id | label", or just "label" to '
+        "derive the id from it. Only for select/multi select questions.",
+    )
+
+    class Meta:
+        model = FormQuestion
+        fields = "__all__"

--- a/backend/generic_forms/tests/test_forms.py
+++ b/backend/generic_forms/tests/test_forms.py
@@ -1,0 +1,125 @@
+import pytest
+
+from generic_forms.forms import FormQuestionInlineForm, OptionsField
+from generic_forms.models import FormQuestion
+from generic_forms.tests.factories import FormFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_options_render_as_one_option_per_line():
+    field = OptionsField(required=False)
+
+    value = field.prepare_value(
+        [
+            {"id": "vegan", "label": "Vegan"},
+            {"id": "veggie", "label": "Veggie"},
+        ]
+    )
+
+    assert value == "vegan | Vegan\nveggie | Veggie"
+
+
+def test_lines_parse_back_to_options():
+    field = OptionsField(required=False)
+
+    assert field.to_python("vegan | Vegan\nveggie | Veggie") == [
+        {"id": "vegan", "label": "Vegan"},
+        {"id": "veggie", "label": "Veggie"},
+    ]
+
+
+def test_a_bare_label_gets_a_slugified_id():
+    field = OptionsField(required=False)
+
+    assert field.to_python("No preference") == [
+        {"id": "no-preference", "label": "No preference"}
+    ]
+
+
+def test_blank_lines_are_ignored():
+    field = OptionsField(required=False)
+
+    assert field.to_python("\nVegan\n\n  \nVeggie\n") == [
+        {"id": "vegan", "label": "Vegan"},
+        {"id": "veggie", "label": "Veggie"},
+    ]
+
+
+def test_labels_can_contain_pipes():
+    field = OptionsField(required=False)
+
+    assert field.to_python("both | One | Two") == [{"id": "both", "label": "One | Two"}]
+
+
+def test_empty_input_means_no_options():
+    field = OptionsField(required=False)
+
+    assert field.to_python("") == []
+    assert field.to_python(None) == []
+
+
+def test_already_parsed_values_pass_through():
+    # initial form data is the stored JSON list, not text
+    field = OptionsField(required=False)
+
+    options = [{"id": "vegan", "label": "Vegan"}]
+    assert field.to_python(options) == options
+
+
+def test_inline_form_saves_options_from_text():
+    form = FormFactory()
+
+    question_form = FormQuestionInlineForm(
+        data={
+            "form": form.pk,
+            "label": "Diet",
+            "question_type": FormQuestion.QuestionType.SELECT,
+            "options": "Vegan\nVeggie",
+            "order": 0,
+            "active": "on",
+        }
+    )
+
+    assert question_form.is_valid(), question_form.errors
+    question = question_form.save()
+    assert question.options == [
+        {"id": "vegan", "label": "Vegan"},
+        {"id": "veggie", "label": "Veggie"},
+    ]
+
+
+def test_inline_form_surfaces_duplicate_id_errors():
+    form = FormFactory()
+
+    question_form = FormQuestionInlineForm(
+        data={
+            "form": form.pk,
+            "label": "Diet",
+            "question_type": FormQuestion.QuestionType.SELECT,
+            "options": "dup | One\ndup | Two",
+            "order": 0,
+            "active": "on",
+        }
+    )
+
+    assert not question_form.is_valid()
+    assert "options" in question_form.errors
+
+
+def test_inline_form_rejects_options_on_text_questions():
+    form = FormFactory()
+
+    question_form = FormQuestionInlineForm(
+        data={
+            "form": form.pk,
+            "label": "Why?",
+            "question_type": FormQuestion.QuestionType.TEXT,
+            "options": "Vegan",
+            "order": 0,
+            "active": "on",
+        }
+    )
+
+    assert not question_form.is_valid()
+    assert "options" in question_form.errors


### PR DESCRIPTION
## Summary

Follow-up on the stack (base: #4711's branch). Organizers asked for something friendlier than the raw JSON widget when editing select/multi-select options.

- `OptionsField`: textarea, **one option per line** — either `id | label` or just `label` (id slugified from it, e.g. `No preference` → `no-preference`)
- Round-trips with the stored `[{"id": ..., "label": ...}]` JSON; labels may contain `|` (first pipe splits)
- Wired into `FormQuestionInline`; model validation stays the source of truth (shape, unique ids, options-only-on-select-types, freeze-on-answer) and surfaces as normal form errors
- No JS, no new dependencies

Supersedes spec decision #7 ("raw JSON widget acceptable") per review feedback.

## Test plan

- [x] 10 new tests: render/parse round-trip, slugified bare labels, blank lines, pipes in labels, empty input, list passthrough (redisplay), inline-form save from text, duplicate-id + options-on-text-question errors surfacing on the `options` field
- [x] Full suite 1273 passed (fresh test DB); ruff + format clean

Stack: #4705 → #4707 → #4709 → #4710 → #4711 → **this**.