### PR TITLE
Generic form system: dynamic answers in the grant review screen (PR 8)

### DIFF
--- a/backend/reviews/adapters.py
+++ b/backend/reviews/adapters.py
@@ -26,6 +26,7 @@ from custom_admin.audit import (
     create_change_admin_log_entry,
     create_deletion_admin_log_entry,
 )
+from generic_forms.services import display_answers
 from grants.models import Grant, GrantReimbursement, GrantReimbursementCategory
 from participants.models import Participant
 from reviews.models import AvailableScoreOption, ReviewSession, UserReview
@@ -621,7 +622,7 @@ class GrantsReviewAdapter:
         )
         comment = request.GET.get("comment", user_review.comment if user_review else "")
 
-        grant = Grant.objects.get(id=review_item_id)
+        grant = Grant.objects.select_related("form_answer__form").get(id=review_item_id)
         previous_grants = Grant.objects.filter(
             user_id=grant.user_id,
             conference__organizer_id=grant.conference.organizer_id,
@@ -630,6 +631,9 @@ class GrantsReviewAdapter:
         return dict(
             admin_site.each_context(request),
             grant=grant,
+            grant_answers=(
+                display_answers(grant.form_answer) if grant.form_answer_id else []
+            ),
             has_sent_proposal=Submission.objects.non_cancelled()
             .filter(
                 speaker_id=grant.user_id,

--- a/backend/reviews/management/commands/seed_review_data.py
+++ b/backend/reviews/management/commands/seed_review_data.py
@@ -141,9 +141,7 @@ class Command(BaseCommand):
             topic, _ = Topic.objects.get_or_create(name=topic_name)
             conference.topics.add(topic)
 
-        en, _ = Language.objects.get_or_create(
-            code="en", defaults={"name": "English"}
-        )
+        en, _ = Language.objects.get_or_create(code="en", defaults={"name": "English"})
         conference.languages.add(en)
 
         for st_name in ["talk", "tutorial"]:
@@ -192,7 +190,9 @@ class Command(BaseCommand):
         # Create some speakers with multiple submissions to test the
         # "speaker has multiple talks" feature
         multi_submission_speakers = []
-        num_multi_speakers = min(3, count // 4)  # ~25% of submissions from repeat speakers
+        num_multi_speakers = min(
+            3, count // 4
+        )  # ~25% of submissions from repeat speakers
         for i in range(num_multi_speakers):
             speaker = User.objects.create_user(
                 email=f"multi-speaker-{uuid.uuid4().hex[:8]}@example.org",
@@ -258,17 +258,13 @@ class Command(BaseCommand):
                 speaker=speaker,
                 title=LazyI18nString({"en": title}),
                 abstract=LazyI18nString({"en": f"Abstract for {title}"}),
-                elevator_pitch=LazyI18nString(
-                    {"en": f"A talk about {title.lower()}"}
-                ),
+                elevator_pitch=LazyI18nString({"en": f"A talk about {title.lower()}"}),
                 notes=f"Speaker notes for {title}",
                 type=submission_type,
                 duration=duration,
                 topic=topic,
                 audience_level=audience_level,
-                speaker_level=random.choice(
-                    [c[0] for c in Submission.SPEAKER_LEVELS]
-                ),
+                speaker_level=random.choice([c[0] for c in Submission.SPEAKER_LEVELS]),
                 status="proposed",
             )
             submission.languages.add(en)
@@ -315,12 +311,18 @@ class Command(BaseCommand):
                 occupation=random.choice(occupations),
                 grant_type=random.sample(grant_types, k=random.randint(1, 2)),
                 python_usage=f"I use Python for {random.choice(['web dev', 'data science', 'automation', 'ML', 'teaching'])}.",
-                been_to_other_events=random.choice(["Yes, PyCon US", "No", "EuroPython 2023"]),
+                been_to_other_events=random.choice(
+                    ["Yes, PyCon US", "No", "EuroPython 2023"]
+                ),
                 needs_funds_for_travel=random.choice([True, False]),
                 why=f"I want to attend because {random.choice(['I want to learn', 'I want to network', 'I want to speak', 'I love Python'])}.",
                 departure_country=random.choice(["IT", "DE", "FR", "US", "GB", "ES"]),
-                departure_city=random.choice(["Rome", "Berlin", "Paris", "New York", "London", "Madrid"]),
-                nationality=random.choice(["Italian", "German", "French", "American", "British", "Spanish"]),
+                departure_city=random.choice(
+                    ["Rome", "Berlin", "Paris", "New York", "London", "Madrid"]
+                ),
+                nationality=random.choice(
+                    ["Italian", "German", "French", "American", "British", "Spanish"]
+                ),
             )
             grants.append(grant)
 
@@ -338,7 +340,9 @@ class Command(BaseCommand):
 
         score_options = self._create_score_options(review_session)
 
-        self.stdout.write(f"Creating {num_submissions} submissions (some speakers will have multiple talks)...")
+        self.stdout.write(
+            f"Creating {num_submissions} submissions (some speakers will have multiple talks)..."
+        )
         submissions = self._create_submissions(conference, num_submissions)
 
         self.stdout.write(f"Creating reviews for {len(submissions)} submissions...")
@@ -359,9 +363,7 @@ class Command(BaseCommand):
 
         review_session.status = "reviewing"
         review_session.save()
-        self.stdout.write(
-            f"  Proposals review session ready (ID: {review_session.id})"
-        )
+        self.stdout.write(f"  Proposals review session ready (ID: {review_session.id})")
 
     def _create_grants_review(self, conference, reviewers, num_grants):
         self.stdout.write("\n--- Grants Review Session ---")

--- a/backend/reviews/tasks.py
+++ b/backend/reviews/tasks.py
@@ -22,9 +22,7 @@ def compute_recap_analysis(conference_id, combined_cache_key, force_recompute=Fa
     try:
         conference = Conference.objects.get(id=conference_id)
     except Conference.DoesNotExist:
-        logger.error(
-            "Conference %s not found for recap analysis", conference_id
-        )
+        logger.error("Conference %s not found for recap analysis", conference_id)
         cache.delete(f"{combined_cache_key}:computing")
         return
 
@@ -58,9 +56,7 @@ def compute_recap_analysis(conference_id, combined_cache_key, force_recompute=Fa
                 }
                 for s in accepted_submissions
             ],
-            key=lambda x: max(
-                (item["similarity"] for item in x["similar"]), default=0
-            ),
+            key=lambda x: max((item["similarity"] for item in x["similar"]), default=0),
             reverse=True,
         )
 

--- a/backend/reviews/templates/grant-review.html
+++ b/backend/reviews/templates/grant-review.html
@@ -218,31 +218,48 @@
     <fieldset class="module aligned">
         <h2>Answers</h2>
 
+        {% for label, value in grant_answers %}
+            <div class="review-row">
+                <strong>{{ label }}</strong>
+                <div>{{ value|linebreaksbr }}</div>
+            </div>
+        {% endfor %}
 
-        <div class="review-row">
-            <strong>Why are you asking for a grant?</strong>
-            <div>{{ grant.why|linebreaksbr }}</div>
-        </div>
+        {# legacy columns; empty for grants submitted through the generic form #}
+        {% if grant.why %}
+            <div class="review-row">
+                <strong>Why are you asking for a grant?</strong>
+                <div>{{ grant.why|linebreaksbr }}</div>
+            </div>
+        {% endif %}
 
-        <div class="review-row">
-            <strong>How do they use python</strong>
-            <div>{{ grant.python_usage|linebreaksbr }}</div>
-        </div>
+        {% if grant.python_usage %}
+            <div class="review-row">
+                <strong>How do they use python</strong>
+                <div>{{ grant.python_usage|linebreaksbr }}</div>
+            </div>
+        {% endif %}
 
-        <div class="review-row">
-            <strong>Have they been to other events?</strong>
-            <div>{{ grant.been_to_other_events|linebreaksbr }}</div>
-        </div>
+        {% if grant.been_to_other_events %}
+            <div class="review-row">
+                <strong>Have they been to other events?</strong>
+                <div>{{ grant.been_to_other_events|linebreaksbr }}</div>
+            </div>
+        {% endif %}
 
-        <div class="review-row">
-            <strong>Community contribution</strong>
-            <div>{{ grant.community_contribution|linebreaksbr }}</div>
-        </div>
+        {% if grant.community_contribution %}
+            <div class="review-row">
+                <strong>Community contribution</strong>
+                <div>{{ grant.community_contribution|linebreaksbr }}</div>
+            </div>
+        {% endif %}
 
-        <div class="review-row">
-            <strong>Notes</strong>
-            <div>{{ grant.notes|linebreaksbr }}</div>
-        </div>
+        {% if grant.notes %}
+            <div class="review-row">
+                <strong>Notes</strong>
+                <div>{{ grant.notes|linebreaksbr }}</div>
+            </div>
+        {% endif %}
 
     </fieldset>
 

--- a/backend/reviews/tests/test_adapters.py
+++ b/backend/reviews/tests/test_adapters.py
@@ -1,0 +1,72 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from generic_forms.models import Form, FormQuestion
+from generic_forms.services import wrap_answers
+from generic_forms.tests.factories import (
+    FormAnswerFactory,
+    FormFactory,
+    FormQuestionFactory,
+)
+from grants.tests.factories import GrantFactory
+from reviews.adapters import GrantsReviewAdapter
+from reviews.tests.factories import ReviewSessionFactory
+from users.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _review_context(grant):
+    review_session = ReviewSessionFactory(
+        session_type="grants", conference=grant.conference
+    )
+    request = RequestFactory().get("/")
+    request.user = UserFactory(is_staff=True, is_superuser=True)
+
+    return GrantsReviewAdapter().get_review_context(
+        request,
+        review_session,
+        grant.id,
+        None,
+        AdminSite(),
+    )
+
+
+def test_review_context_includes_dynamic_answers():
+    grant = GrantFactory()
+    form = FormFactory(conference=grant.conference, purpose=Form.Purpose.GRANT)
+    why = FormQuestionFactory(
+        form=form,
+        label="Why do you need it?",
+        question_type=FormQuestion.QuestionType.TEXTAREA,
+        order=0,
+    )
+    diet = FormQuestionFactory(
+        form=form,
+        label="Diet",
+        question_type=FormQuestion.QuestionType.SELECT,
+        options=[{"id": "vegan", "label": "Vegan"}],
+        order=1,
+    )
+    grant.form_answer = FormAnswerFactory(
+        form=form,
+        user=grant.user,
+        answers=wrap_answers({str(why.pk): "My motivation", str(diet.pk): "vegan"}),
+    )
+    grant.save()
+
+    context = _review_context(grant)
+
+    assert context["grant_answers"] == [
+        ("Why do you need it?", "My motivation"),
+        ("Diet", "Vegan"),
+    ]
+
+
+def test_review_context_has_no_answers_for_legacy_grants():
+    grant = GrantFactory()
+
+    context = _review_context(grant)
+
+    assert context["grant_answers"] == []

--- a/backend/reviews/tests/test_similar_talks.py
+++ b/backend/reviews/tests/test_similar_talks.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 
 from reviews.similar_talks import (
     compute_similar_talks,
@@ -9,7 +8,9 @@ from reviews.similar_talks import (
 )
 
 
-def _make_submission(id, title="Test Talk", elevator_pitch="A pitch", abstract="Abstract"):
+def _make_submission(
+    id, title="Test Talk", elevator_pitch="A pitch", abstract="Abstract"
+):
     """Create a mock submission object."""
     sub = MagicMock()
     sub.id = id
@@ -37,11 +38,13 @@ class TestComputeSimilarTalks:
     def test_returns_similar_talks(self, mock_cache, mock_model):
         mock_cache.get.return_value = None
 
-        embeddings = np.array([
-            [1.0, 0.0, 0.0],
-            [0.9, 0.1, 0.0],
-            [0.0, 0.0, 1.0],
-        ])
+        embeddings = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.9, 0.1, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
         mock_model.return_value.encode.return_value = embeddings
 
         subs = [
@@ -99,7 +102,11 @@ class TestComputeTopicClusters:
         mock_model.assert_not_called()
 
     def test_uses_cache(self, mock_cache, mock_model):
-        cached = {"topics": [{"name": "Cached"}], "outliers": [], "submission_topics": {}}
+        cached = {
+            "topics": [{"name": "Cached"}],
+            "outliers": [],
+            "submission_topics": {},
+        }
         mock_cache.get.return_value = cached
 
         subs = [_make_submission(i) for i in range(5)]


### PR DESCRIPTION
## Summary

Stacked on #4717. Reviewers see the dynamic form answers when scoring grants.

- `GrantsReviewAdapter.get_review_context` adds `grant_answers`: `(question label, formatted value)` pairs from the linked `FormAnswer` via the shared `display_answers` helper (question-ordered, option ids resolved to labels, Yes/No booleans); empty list for legacy grants. Grant is fetched with `select_related("form_answer__form")`.
- `grant-review.html` "Answers" section renders the pairs; the five legacy hardcoded rows are now wrapped in `{% if %}` so generic-form grants (whose columns are empty) don't show blank rows — historical grants render exactly as before.

## Test plan

- [x] Adapter tests: context carries ordered label/value pairs for a grant with answers; empty list for legacy grants
- [x] Full suite 1275 passed; ruff + format clean on touched files (one pre-existing F401 in `reviews/tests/test_similar_talks.py` left alone)

Stack: … → #4711 → #4716 → #4717 → **this**.