### PR TITLE
Use t4g.large server for now

### DIFF
--- a/infrastructure/applications/cluster/server.tf
+++ b/infrastructure/applications/cluster/server.tf
@@ -12,7 +12,7 @@ resource "aws_eip" "server" {
 
 resource "aws_instance" "server" {
   ami               = "ami-0a3cd3b991bec2dd7"
-  instance_type     = local.is_prod ? "r6g.medium" : "t4g.small"
+  instance_type     = local.is_prod ? "t4g.large" : "t4g.small"
   subnet_id         = var.public_1a_subnet_id
   availability_zone = "eu-central-1a"
   vpc_security_group_ids = [


### PR DESCRIPTION
## What

- r6g.medium reserved instance expires in a few days. 
- r6g also doesn't scale well due to the limited CPU and ends up crashing under load
- We might move off EC2 again to reduce costs anyway


