### PR TITLE
Fix confirmed Django N+1 queries

### DIFF
--- a/backend/conferences/admin/conference.py
+++ b/backend/conferences/admin/conference.py
@@ -283,7 +283,9 @@ class ConferenceAdmin(
         return render(request, "admin/videos_upload/map_videos.html", context)
 
     def save_manual_changes(self, request, object_id, data):
-        all_events = ScheduleItem.objects.filter(conference_id=object_id)
+        all_events = ScheduleItem.objects.select_related(
+            "submission", "keynote", "language"
+        ).filter(conference_id=object_id)
 
         for event in all_events:
             key_name = f"video_uploaded_path_{event.id}"
@@ -303,9 +305,16 @@ class ConferenceAdmin(
 
     def run_video_uploaded_path_matcher(self, request, object_id, ignore_cache):
         conference = Conference.objects.get(pk=object_id)
-        all_events = conference.schedule_items.prefetch_related(
-            "submission", "additional_speakers"
-        ).all()
+        all_events = (
+            conference.schedule_items.select_related(
+                "submission__speaker", "keynote", "language"
+            )
+            .prefetch_related(
+                "additional_speakers__user",
+                "keynote__speakers__user",
+            )
+            .all()
+        )
 
         cache_key = f"{conference.code}:video-upload-files-cache"
         files = cache.get(cache_key)

--- a/backend/grants/admin.py
+++ b/backend/grants/admin.py
@@ -760,7 +760,7 @@ class GrantAdmin(ExportMixin, ConferencePermissionMixin, admin.ModelAdmin):
         qs = (
             super()
             .get_queryset(request)
-            .select_related("user")
+            .select_related("user", "conference")
             .prefetch_related("reimbursements__category")
             .annotate(
                 is_proposed_speaker=Exists(

--- a/backend/grants/models.py
+++ b/backend/grants/models.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 from django.db import models
+from django.db.models import prefetch_related_objects
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from model_utils.models import TimeStampedModel
@@ -307,10 +308,12 @@ class Grant(TimeStampedModel):
     @property
     def total_grantee_reimbursement_amount(self) -> Decimal:
         """Return total reimbursement excluding ticket."""
+        reimbursements = list(self.reimbursements.all())
+        prefetch_related_objects(reimbursements, "category")
         return sum(
             (
                 r.granted_amount
-                for r in self.reimbursements.all()
+                for r in reimbursements
                 if r.category.category != GrantReimbursementCategory.Category.TICKET
             ),
             start=Decimal(0),

--- a/backend/grants/tasks.py
+++ b/backend/grants/tasks.py
@@ -78,7 +78,7 @@ def create_and_send_voucher_to_grantee(*, grant_id: int) -> None:
 @app.task
 def send_grant_reply_approved_email(*, grant_id: int, is_reminder: bool) -> None:
     logger.info("Sending Reply APPROVED email for Grant %s", grant_id)
-    grant = Grant.objects.get(id=grant_id)
+    grant = Grant.objects.prefetch_related("reimbursements__category").get(id=grant_id)
 
     total_amount = grant.total_grantee_reimbursement_amount
     ticket_only = grant.has_ticket_only()

--- a/backend/grants/tests/test_models.py
+++ b/backend/grants/tests/test_models.py
@@ -254,6 +254,28 @@ def test_total_grantee_reimbursement_amount_excludes_ticket():
     assert grant.total_grantee_reimbursement_amount == Decimal("700")
 
 
+def test_total_grantee_reimbursement_amount_batches_categories(
+    django_assert_num_queries,
+):
+    grant = GrantFactory()
+    GrantReimbursementFactory(
+        grant=grant,
+        category__conference=grant.conference,
+        category__travel=True,
+        granted_amount=Decimal("500"),
+    )
+    GrantReimbursementFactory(
+        grant=grant,
+        category__conference=grant.conference,
+        category__accommodation=True,
+        granted_amount=Decimal("200"),
+    )
+    grant = Grant.objects.get(pk=grant.pk)
+
+    with django_assert_num_queries(2):
+        assert grant.total_grantee_reimbursement_amount == Decimal("700")
+
+
 def test_total_grantee_reimbursement_amount_with_only_ticket():
     grant = GrantFactory()
     GrantReimbursementFactory(

--- a/backend/integrations/plain_cards.py
+++ b/backend/integrations/plain_cards.py
@@ -4,7 +4,10 @@ from grants.models import Grant
 
 def create_grant_card(request, user, conference):
     grant = (
-        Grant.objects.of_user(user).for_conference(conference).first()
+        Grant.objects.of_user(user)
+        .for_conference(conference)
+        .prefetch_related("reimbursements__category")
+        .first()
         if user
         else None
     )

--- a/backend/reviews/adapters.py
+++ b/backend/reviews/adapters.py
@@ -506,7 +506,16 @@ class GrantsReviewAdapter:
             if key.startswith("notes-")
         }
 
-        grants = list(review_session.conference.grants.filter(id__in=decisions.keys()))
+        grants = list(
+            review_session.conference.grants.filter(
+                id__in=decisions.keys()
+            ).prefetch_related(
+                Prefetch(
+                    "reimbursements",
+                    queryset=GrantReimbursement.objects.select_related("category"),
+                )
+            )
+        )
 
         # Track grants with pending status changes for audit logging
         grants_with_pending_status_changes = {}
@@ -526,13 +535,14 @@ class GrantsReviewAdapter:
                 grants_with_pending_status_changes[grant.id] = original_pending_status
 
             # Handle reimbursement deletions
-            if grant.reimbursements.exists():
+            reimbursements = list(grant.reimbursements.all())
+            if reimbursements:
                 approved_reimbursement_categories = (
                     approved_reimbursement_categories_decisions.get(grant.id, [])
                 )
                 if decision != Grant.Status.approved:
                     # Delete all reimbursements if not approved
-                    for reimbursement in grant.reimbursements.all():
+                    for reimbursement in reimbursements:
                         create_deletion_admin_log_entry(
                             request.user,
                             grant,
@@ -541,16 +551,21 @@ class GrantsReviewAdapter:
                         reimbursement.delete()
                 else:
                     # Only keep those in current approved categories
-                    to_delete = grant.reimbursements.exclude(
-                        category_id__in=approved_reimbursement_categories
-                    )
+                    to_delete = [
+                        reimbursement
+                        for reimbursement in reimbursements
+                        if reimbursement.category_id
+                        not in approved_reimbursement_categories
+                    ]
                     for reimbursement in to_delete:
                         create_deletion_admin_log_entry(
                             request.user,
                             grant,
                             change_message=f"[Review Session] Reimbursement removed: {reimbursement.category.name}.",
                         )
-                    to_delete.delete()
+                    GrantReimbursement.objects.filter(
+                        id__in=[reimbursement.id for reimbursement in to_delete]
+                    ).delete()
 
         # Save grants and create audit logs
         for grant in grants:

--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -404,7 +404,12 @@ class ScheduleItemAdmin(ConferencePermissionMixin, admin.ModelAdmin):
         return (
             super()
             .get_queryset(request)
-            .prefetch_related("rooms")
+            .select_related("submission__speaker")
+            .prefetch_related(
+                "rooms",
+                "additional_speakers__user",
+                "keynote__speakers__user",
+            )
             .annotate(attendees_count_annotation=Count("attendees", distinct=True))
         )
 

--- a/backend/schedule/models.py
+++ b/backend/schedule/models.py
@@ -5,7 +5,7 @@ from conferences.querysets import ConferenceQuerySetMixin
 
 from django.core import exceptions
 from django.db import models
-from django.db.models import Case, When
+from django.db.models import Case, When, prefetch_related_objects
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -341,11 +341,18 @@ class ScheduleItem(TimeStampedModel):
             speakers.append(self.submission.speaker)
 
         if self.keynote_id:
-            for speaker_keynote in self.keynote.speakers.order_by("id").all():
+            keynote_speakers = list(self.keynote.speakers.all())
+            prefetch_related_objects(keynote_speakers, "user")
+            for speaker_keynote in sorted(
+                keynote_speakers, key=lambda speaker: speaker.id
+            ):
                 speakers.append(speaker_keynote.user)
 
+        additional_speakers = list(self.additional_speakers.all())
+        prefetch_related_objects(additional_speakers, "user")
         speakers.extend(
-            [speaker.user for speaker in self.additional_speakers.order_by("id").all()]
+            speaker.user
+            for speaker in sorted(additional_speakers, key=lambda speaker: speaker.id)
         )
         return [speaker for speaker in speakers if speaker is not None]
 

--- a/backend/schedule/tasks.py
+++ b/backend/schedule/tasks.py
@@ -345,6 +345,7 @@ def process_schedule_items_videos_to_upload():
                 last_attempt_at__lt=timezone.now() - timezone.timedelta(hours=1),
             )
         )
+        .select_related("schedule_item")
         .to_upload()
         .order_by("last_attempt_at")
     )

--- a/backend/schedule/views.py
+++ b/backend/schedule/views.py
@@ -16,17 +16,23 @@ from django.views.decorators.cache import never_cache
 def user_schedule_item_favourites_calendar(request, conference_id, hash_user_id):
     conference = Conference.objects.get(id=conference_id)
     user_id = decode_hashid(hash_user_id, salt=settings.USER_ID_HASH_SALT, min_length=6)
-    starred_schedule_items = ScheduleItem.objects.prefetch_related(
-        "submission",
-        "keynote",
-        "language",
-        "slot",
-        "rooms",
-        "additional_speakers__user",
-    ).filter(
-        id__in=ScheduleItemStar.objects.for_conference(conference)
-        .of_user(user_id)
-        .values_list("schedule_item_id", flat=True)
+    starred_schedule_items = (
+        ScheduleItem.objects.select_related(
+            "submission__speaker",
+            "keynote",
+            "language",
+            "slot__day",
+        )
+        .prefetch_related(
+            "rooms",
+            "additional_speakers__user",
+            "keynote__speakers__user",
+        )
+        .filter(
+            id__in=ScheduleItemStar.objects.for_conference(conference)
+            .of_user(user_id)
+            .values_list("schedule_item_id", flat=True)
+        )
     )
 
     conference_name = conference.name.localize("en")

--- a/backend/visa/models.py
+++ b/backend/visa/models.py
@@ -133,7 +133,12 @@ class InvitationLetterRequest(TimeStampedModel):
 
     @cached_property
     def user_grant(self):
-        return Grant.objects.for_conference(self.conference).of_user(self.user).first()
+        return (
+            Grant.objects.for_conference(self.conference)
+            .of_user(self.user)
+            .prefetch_related("reimbursements__category")
+            .first()
+        )
 
     @property
     def has_grant(self):


### PR DESCRIPTION
## Summary

- batch related-object loading for schedule speakers and grant reimbursements
- preload queryset relations in admin, tasks, reviews, calendar, and visa paths
- add a constant-query regression test for reimbursement category access

## Validation

- django-lsp scan from `backend/`: 12 diagnostics before, 0 after
- 202 focused tests passed, 2 skipped
- Ruff formatting check passed for all touched files
- `git diff --check` passed

The scan used the call-site provenance and nested relation support from patrick91/django-lsp#26.