### PR TITLE
Skip do_not_record proposals when uploading videos to YouTube

### DIFF
--- a/backend/schedule/admin.py
+++ b/backend/schedule/admin.py
@@ -194,8 +194,10 @@ def _send_invitations(
 
 @admin.action(description="Upload videos to YouTube")
 def upload_videos_to_youtube(modeladmin, request, queryset):
-    videos = queryset.filter(youtube_video_id__exact="").exclude(
-        video_uploaded_path__exact=""
+    videos = (
+        queryset.filter(youtube_video_id__exact="")
+        .exclude(video_uploaded_path__exact="")
+        .exclude(submission__do_not_record=True)
     )
 
     sent_for_video_upload_objs = []

--- a/backend/schedule/tests/test_admin.py
+++ b/backend/schedule/tests/test_admin.py
@@ -15,8 +15,9 @@ from schedule.admin import (
     send_schedule_invitation_reminder_to_waiting,
     send_schedule_invitation_to_all,
     send_schedule_invitation_to_uninvited,
+    upload_videos_to_youtube,
 )
-from schedule.models import ScheduleItem
+from schedule.models import ScheduleItem, ScheduleItemSentForVideoUpload
 from schedule.tests.factories import (
     ScheduleItemAdditionalSpeakerFactory,
     ScheduleItemFactory,
@@ -698,3 +699,42 @@ def test_mark_as_confirmed_action(rf, mocker):
 
     assert schedule_item.status == ScheduleItem.STATUS.confirmed
     assert unrelated_schedule_item.status == ScheduleItem.STATUS.waiting_confirmation
+
+
+def test_upload_videos_to_youtube_skips_do_not_record_submissions(rf, mocker):
+    mocker.patch("schedule.admin.messages")
+
+    conference = ConferenceFactory()
+    recordable = ScheduleItemFactory(
+        conference=conference,
+        type=ScheduleItem.TYPES.talk,
+        youtube_video_id="",
+        video_uploaded_path="recordable.mp4",
+        submission=SubmissionFactory(conference=conference, do_not_record=False),
+    )
+    do_not_record = ScheduleItemFactory(
+        conference=conference,
+        type=ScheduleItem.TYPES.talk,
+        youtube_video_id="",
+        video_uploaded_path="do-not-record.mp4",
+        submission=SubmissionFactory(conference=conference, do_not_record=True),
+    )
+    without_submission = ScheduleItemFactory(
+        conference=conference,
+        type=ScheduleItem.TYPES.custom,
+        youtube_video_id="",
+        video_uploaded_path="custom.mp4",
+        submission=None,
+    )
+
+    upload_videos_to_youtube(
+        None, rf.get("/"), ScheduleItem.objects.filter(conference=conference)
+    )
+
+    scheduled_ids = set(
+        ScheduleItemSentForVideoUpload.objects.values_list(
+            "schedule_item_id", flat=True
+        )
+    )
+    assert scheduled_ids == {recordable.id, without_submission.id}
+    assert do_not_record.id not in scheduled_ids


### PR DESCRIPTION
## What

The `Upload videos to YouTube` admin action queued every schedule item that had a video file and no YouTube ID, ignoring `Submission.do_not_record`. On PyCon Italia 2026 this uploaded 4 talks whose speakers had opted out of recording (schedule items 1083, 1160, 1161, 1176), and drafted the "video recording uploaded" email to those speakers.

This adds `.exclude(submission__do_not_record=True)` to the action's queryset. Items without a submission (custom items) are unaffected, since the `exclude` on the join doesn't match `NULL`.

Test: `test_upload_videos_to_youtube_skips_do_not_record_submissions`.

## Notes

- Only the admin action is filtered. `upload_schedule_item_video` / `process_schedule_items_videos_to_upload` still process any `ScheduleItemSentForVideoUpload` rows that already exist, so previously queued do-not-record items are not stopped by this change.
- Unrelated, found while writing the test: `ScheduleItemFactory.type` is still `FuzzyChoice(["submission", "custom"])` even though the `submission` type was removed. When it rolls `custom` the factory drops the `submission` passed in, which makes tests randomly flaky.

## ToDo

- [ ] Decide whether the celery task should also guard on `do_not_record`
- [ ] Clean up the 4 already-uploaded videos + their draft emails on production